### PR TITLE
[Fix] #26 - 토큰 재발급 로직 수정 

### DIFF
--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Component/Bar/MyPageSegmentControlBar.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Component/Bar/MyPageSegmentControlBar.swift
@@ -30,7 +30,6 @@ struct MyPageSegmentControlBar: View {
                     
                     Button {
                         viewModel.selectedCategory = category
-                        viewModel.getMeetings()
                     } label: {
                         ZStack(alignment: .bottom) {
                             Text(category == .register ? "내가 모집한" : "내가 신청한")
@@ -48,9 +47,6 @@ struct MyPageSegmentControlBar: View {
             }
             selectedView()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-        }
-        .onAppear {
-            viewModel.getMeetings()
         }
         .onChange(of: viewModel.selectedCategory) {
             viewModel.getMeetings()

--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Manager/TokenInterceptor.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Manager/TokenInterceptor.swift
@@ -11,52 +11,59 @@ import Alamofire
 
 // Alamofire의 RequestInterceptor를 상속받아 구현
 final class TokenInterceptor: RequestInterceptor {
-
+    
     // 싱글톤 패턴으로 인스턴스 하나만 생성
     static let shared = TokenInterceptor()
-
+    
     private init() {}
-
+    
     
     // 요청이 서버로 보내지기 전 호출됨
     // 토큰 만료로 갱신이 필요할 시
     func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
         
-        // 토큰이 있는지 확인
-        guard let accessToken = TokenManager.shared.accessToken,
-              let refreshToken = TokenManager.shared.refreshToken else {
-            completion(.success(urlRequest)) // 토큰이 없으면 요청을 그대로 반환
-            return
+        var urlRequest = urlRequest
+        let isSignIn: Bool = urlRequest.url?.path.contains("/login") ?? false
+        
+        // 로그인 API 헤더엔 액세스 토큰이 아닌 identityToken이 들어가므로, adapt() 함수 내에서 헤더가 바뀌지 않도록 함.
+        if !isSignIn {
+            if let accessToken = TokenManager.shared.accessToken {
+                // 항상 최신의 액세스 토큰을 사용하도록 함.
+                // 기존 요청 재시도 할 경우 다시 최신 토큰으로 setValue 해주지 않으면 만료된 토큰 그대로 남아있음.
+                urlRequest.setValue(APIConstants.Bearer + accessToken, forHTTPHeaderField: APIConstants.auth)
+            }
         }
         
-        // 요청 헤더에 accessToken과 refreshToken을 추가
-        var urlRequest = urlRequest
-        urlRequest.setValue(accessToken, forHTTPHeaderField: APIConstants.access)
-        urlRequest.setValue(refreshToken, forHTTPHeaderField: APIConstants.refresh)
-        
-        print("adator 적용 \(urlRequest.headers)")
+        print("🍏 adaptor 적용 헤더: \(urlRequest.headers)")
         completion(.success(urlRequest))
     }
-
+    
     // 요청 실패 시 호출
     // 토큰 만료 에러일 경우 토큰 갱신 후 기존 요청 재시도
     func retry(_ request: Request, for session: Session, dueTo error: Error, completion: @escaping (RetryResult) -> Void) {
+        print("-------🔧retry 시작🔧-------")
         
-        
-        guard let response = request.task?.response as? HTTPURLResponse, response.statusCode == 401
+        guard let response = request.response, response.statusCode == 401
         else {
             // 401X 에러가 아니라면 재시도 하지 않고 오류를 그대로 반환
             completion(.doNotRetryWithError(error))
             return
         }
-
-        // 토큰 갱신 API 호출
-        TokenManager.shared.reissueToken { success in
-            if success {
-                print("토큰 갱신 완료 -> 기존 요청 재시도")
+        
+        Providers.SignupProvider.request(
+            target: .patchReissue,
+            instance: BaseResponse<PatchReissueResponse>.self
+        ) { response in
+            if response.success {
+                print("토큰 재발급 완료 -> 기존 요청 재시도")
+                if let tokenData = response.data {
+                    TokenManager.shared.updateToken(tokenData.accessToken, tokenData.refreshToken)
+                }
                 completion(.retry)
             } else {
                 print("🚨 토큰 갱신 실패")
+                TokenManager.shared.clearAll()
+                // 내비게이션 매니저 필요한디... 루트뷰 로그인화면으로 바꿔야 함... 어떻게 가져올까 고민해봐야 할듯 ㅠ
                 completion(.doNotRetryWithError(error))
             }
         }

--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Manager/TokenManager.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Manager/TokenManager.swift
@@ -69,25 +69,6 @@ extension TokenManager {
         self.refreshToken = refreshToken
     }
     
-    func reissueToken(completion: @escaping (Bool) -> Void) {        
-        Providers.authProvider.request(
-            target: .patchReissue,
-            instance: BaseResponse<PatchReissueResponse>.self
-        ) { response in
-            
-            guard response.success, let data = response.data else {
-                print("토큰 재발급 실패! \(response.message ?? "알 수 없음")")
-                completion(false)
-                return
-            }
-            
-            print("토큰 재발급 성공")
-            
-            // 키체인에 새로운 토큰 저장
-            TokenManager.shared.updateToken(data.accessToken, data.refreshToken)
-        }
-    }
-    
     func updateFcmToken(_ fcmToken: String) {
         self.fcmToken = fcmToken
     }

--- a/Gongbaek_iOS/Gongbaek_iOS/Network/Environment/APIConstants.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Network/Environment/APIConstants.swift
@@ -17,32 +17,26 @@ struct APIConstants{
     static let refresh = "refreshToken"
     static let accessToken = "Bearer " + ""
     static let refreshToken = "Bearer " + ""
-    static var authCode = ""
     static let Bearer = "Bearer "
 }
 
 extension APIConstants {
-    static let authCodeHeader: [String: String] = [
-        contentType: applicationJSON,
-        auth: Bearer + authCode
-    ]
-    
-    static let hasContentTypeHeader: [String: String] = [
+    static let contentTypeHeader: [String: String] = [
         contentType: applicationJSON
     ]
     
-    static var appleAuthHeader: [String: String] = [
-        contentType: applicationJSON,
-        auth: TokenManager.shared.identityTokenValue
-    ]
+    static var appleAuthHeader: [String: String] {
+        [contentType: applicationJSON,
+            auth: TokenManager.shared.identityTokenValue]
+    }
     
-    static var accessTokenHeader: [String: String] = [
-        contentType: applicationJSON,
-        auth: Bearer + TokenManager.shared.accessTokenValue
-    ]
+    static var accessTokenHeader: [String: String] {
+        [contentType: applicationJSON,
+                auth: Bearer + TokenManager.shared.accessTokenValue]
+    }
     
-    static var refreshTokenHeader: [String: String] = [
-        contentType: applicationJSON,
-        auth: TokenManager.shared.refreshTokenValue
-    ]
+    static var refreshTokenHeader: [String: String] {
+        [contentType: applicationJSON,
+                auth: Bearer + TokenManager.shared.refreshTokenValue]
+    }
 }

--- a/Gongbaek_iOS/Gongbaek_iOS/Network/Service/Providers.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Network/Service/Providers.swift
@@ -10,14 +10,14 @@ import Foundation
 import Moya
 
 struct Providers {
-    static let authProvider = NetworkProvider<AuthTargetType>(withAuth: false)
-    static let homeProvider = NetworkProvider<HomeTargetType>(withAuth: false)
-    static let fillingProvider = NetworkProvider<FillingTargetType>(withAuth: false)
-    static let meetingRoomProvider = NetworkProvider<MeetingRoomTargetType>(withAuth: false)
-    static let meetingDetailProvider = NetworkProvider<MeetingDetailTargetType>(withAuth: false)
-    static let commentProvider = NetworkProvider<CommentTargetType>(withAuth: false)
+    static let authProvider = NetworkProvider<AuthTargetType>(withAuth: true)
+    static let homeProvider = NetworkProvider<HomeTargetType>(withAuth: true)
+    static let fillingProvider = NetworkProvider<FillingTargetType>(withAuth: true)
+    static let meetingRoomProvider = NetworkProvider<MeetingRoomTargetType>(withAuth: true)
+    static let meetingDetailProvider = NetworkProvider<MeetingDetailTargetType>(withAuth: true)
+    static let commentProvider = NetworkProvider<CommentTargetType>(withAuth: true)
     static let SignupProvider = NetworkProvider<SignupTargetType>(withAuth: false)
-    static let mypageProvider = NetworkProvider<MyPageTargetType>(withAuth: false)
+    static let mypageProvider = NetworkProvider<MyPageTargetType>(withAuth: true)
 }
 
 extension MoyaProvider {

--- a/Gongbaek_iOS/Gongbaek_iOS/Network/Service/TargetType/AuthTargetType.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Network/Service/TargetType/AuthTargetType.swift
@@ -9,7 +9,6 @@ import Moya
 
 enum AuthTargetType {
     case postSignin(requestBody: PostSigninRequestDTO)
-    case patchReissue
     case deleteLogout
     case deleteWidthdraw
 }
@@ -19,8 +18,6 @@ extension AuthTargetType: BaseTargetType {
         switch self {
         case .postSignin:
             return APIConstants.appleAuthHeader
-        case .patchReissue:
-            return APIConstants.refreshTokenHeader
         case .deleteLogout:
             return APIConstants.accessTokenHeader
         case .deleteWidthdraw:
@@ -32,8 +29,6 @@ extension AuthTargetType: BaseTargetType {
         switch self {
         case .postSignin:
             return "/api/v1/login"
-        case .patchReissue:
-            return "/api/v1/reissue/token"
         case .deleteLogout:
             return "/api/v1/logout"
         case .deleteWidthdraw:
@@ -45,8 +40,6 @@ extension AuthTargetType: BaseTargetType {
         switch self {
         case .postSignin:
             return .post
-        case .patchReissue:
-            return .patch
         case .deleteLogout, .deleteWidthdraw:
             return .delete
         }
@@ -56,7 +49,7 @@ extension AuthTargetType: BaseTargetType {
         switch self {
         case .postSignin(let requstBody):
             return .requestJSONEncodable(requstBody)
-        case .patchReissue, .deleteLogout, .deleteWidthdraw:
+        case .deleteLogout, .deleteWidthdraw:
             return .requestPlain
         }
     }

--- a/Gongbaek_iOS/Gongbaek_iOS/Network/Service/TargetType/SignupTargetType.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Network/Service/TargetType/SignupTargetType.swift
@@ -8,6 +8,7 @@
 import Moya
 
 enum SignupTargetType {
+    case patchReissue
     case postNicknameValidation(nickname: String)
     case getSchoolSearchResults(schoolName: String)
     case getMajorSearchResults(schoolName: String, majorName: String)
@@ -17,19 +18,23 @@ enum SignupTargetType {
 extension SignupTargetType: BaseTargetType {
     var headers: Parameters? {
         switch self {
+        case .patchReissue:
+            return APIConstants.refreshTokenHeader
         case .postNicknameValidation:
-            return APIConstants.hasContentTypeHeader
+            return APIConstants.contentTypeHeader
         case .getSchoolSearchResults:
-            return APIConstants.hasContentTypeHeader
+            return APIConstants.contentTypeHeader
         case .getMajorSearchResults:
-            return APIConstants.hasContentTypeHeader
+            return APIConstants.contentTypeHeader
         case .postSignup:
-            return APIConstants.hasContentTypeHeader
+            return APIConstants.contentTypeHeader
         }
     }
     
     var path: String {
         switch self {
+        case .patchReissue:
+            return "/api/v1/reissue/token"
         case .postNicknameValidation:
             return "/api/v1/user/validate/nickname"
         case .getSchoolSearchResults:
@@ -43,6 +48,8 @@ extension SignupTargetType: BaseTargetType {
     
     var method: Moya.Method {
         switch self {
+        case .patchReissue:
+            return .patch
         case .postNicknameValidation:
             return .post
         case .getSchoolSearchResults:
@@ -56,6 +63,8 @@ extension SignupTargetType: BaseTargetType {
     
     var task: Moya.Task {
         switch self {
+        case .patchReissue:
+            return .requestPlain
         case .postNicknameValidation(let nickname):
             return .requestParameters(
                 parameters: ["nickname" : nickname],

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MyPage/View/MyPageView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MyPage/View/MyPageView.swift
@@ -40,7 +40,6 @@ struct MyPageView: View {
         .customNavigationBar(title: "마이페이지")
         .onAppear {
             viewModel.getMyProfile()
-            viewModel.getMeetings()
         }
     }
 }


### PR DESCRIPTION
## 🧩 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
토큰 재발급 로직 수정했습니다!

## 🪁 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
엄마는 천재가 아닐까 시프다...으앙

### 1️⃣ TokenIntercepor
나는 바보였어 엄마의 주석 덕분에 쏙쏙 이해함! ㅎㅎ
토큰 갱신하는 API를 따로 빼야하나 고민중이었는데 완전 똑똑하게 빼줬어 짱이야


### 2️⃣ 나의 채움 API 중복 호출
엄마 덕분에 확인해보니까 SegmentControl에서 이미 `.onAppear`와 `.onChange`에서 API호출 해주고 있었는데
모르고 MyPageView의 `.onAppear`에서 . 또 호출하고 있어서 삭제 했습니다

해당 부분을 제거한 후에도 여전히 중복 호출이 발생해 확인해보니,
SegmentControl 내 버튼 탭 시 `viewModel.selectedCategory = category`를 통해
직접 값을 변경하면서 API가 다시 호출되고 있었어욤
하지만 해당 값 변경 시 `.onChange`에서 이미 getMeetings()가 호출되기 때문에, 버튼 탭 시 API를 직접 호출하는 부분도 제거하고
초기값으로 인해 .onAppear 역시 불필요하므로 함께 정리했습니당

듀아아 다들 미안해 나때매 불편했지이 ㅜㅜ 어서 머지 퍼가슈
![image](https://github.com/user-attachments/assets/82bc833e-daf0-46d5-af16-bcf8c46efb34)


## 📱 스크린샷
<!-- 작업 내용, 스크린 샷(GIF/MP4) 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 구현내용입력 | <img src = "" width ="300">|


### 🔗 Issue 
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #26
