### PR TITLE
[Chore] #17 - 탭 바 상단 스트로크 추가

### DIFF
--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Component/Bar/Common/CustomTabBar.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Component/Bar/Common/CustomTabBar.swift
@@ -33,6 +33,10 @@ struct CustomTabBar: View {
         .padding(.vertical, 8)
         .padding(.horizontal, 50)
         .background(.grayWhite)
+        .overlay(
+            Color.gray02.frame(height: 1),
+            alignment: .top
+        )
     }
     
     func tabButton (


### PR DESCRIPTION
## 🧩 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
탭바 상단에 stroke 추가

## 🪁 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
1커밋 1푸시...

탭바 상단에 stroke 추가,
탭 바 사이즈는 그대로, inside로 추가된 것으로 `overlay`를 사용하여 스트로크 추가하였습니다.

## 📱 스크린샷
<!-- 작업 내용, 스크린 샷(GIF/MP4) 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 구현내용입력 | <img width="300" alt="스크린샷 2025-04-18 오전 2 27 26" src="https://github.com/user-attachments/assets/8d60d3d6-ee33-4c44-ae0b-106647056f61" />|


### 🔗 Issue 
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #17
