### PR TITLE
[Feat] #25 - 회원가입 과정 내의 API 연결 및 에러 대응

### DIFF
--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Component/TextField/CustomTextEditor.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Component/TextField/CustomTextEditor.swift
@@ -11,7 +11,7 @@ struct CustomTextEditor: View {
     @Binding var text: String
     @FocusState var isEditing: Bool
     private let isSignupView: Bool
-    let maxCharacterCount = 100
+    private let maxCharacterCount = 100
     
     init(text: Binding<String>, isSignupView: Bool = false) {
         self._text = text
@@ -27,12 +27,12 @@ struct CustomTextEditor: View {
             ZStack(alignment: .topLeading) {
                 if text.isEmpty {
                     Text(
-                        isSignupView ?
-                         "간단한 소개글을 입력해보세요.\nex) 안녕하세요. 복학한 화석입니다. 사람들을 좋아하고 함께하는 활동을 좋아해요." :
-                        "간단한 소개글을 20자 이상 작성해보세요.\nex) 화석된 사람들끼리 소소한 점심 모임 어때요?"
+                        isSignupView
+                        ? "간단한 소개글을 20자 이상 작성해보세요.\nex) 안녕하세요! 이번에 복학한 학생입니다. 함께 좋은 모임 만들어봐요~!"
+                        : "간단한 소개글을 20자 이상 작성해보세요.\nex) 화석된 사람들끼리 소소한 점심 모임 어때요?"
                     )
-                        .foregroundColor(.gray04)
-                        .padding(EdgeInsets(top: 14, leading: 16, bottom: 14, trailing: 16))
+                    .foregroundColor(.gray04)
+                    .padding(EdgeInsets(top: 14, leading: 16, bottom: 14, trailing: 16))
                 }
 
                 TextEditor(text: $text)

--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Component/TextField/CustomTextFieldWithStatus.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Component/TextField/CustomTextFieldWithStatus.swift
@@ -27,12 +27,15 @@ struct CustomTextFieldWithStatus<Status: TextFieldErrorStatus>: View {
                     isFocused: $isFocused,
                     type: type
                 )
+                .autocorrectionDisabled(true)
+                .textInputAutocapitalization(.never)
                 .overlay(
                     RoundedRectangle(cornerRadius: 6)
                         .stroke(strokeColor(), lineWidth: 1)
                 )
                 .onChange(of: text) {
-                    if status != nil {
+                    if status as? TextFieldType.VerificationStatus != .expiredCode,
+                       status != nil {
                         self.status = nil
                     }
                 }

--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Enum/TextFieldType.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Enum/TextFieldType.swift
@@ -21,7 +21,7 @@ enum TextFieldType {
     
     enum NicknameStatus: String, TextFieldErrorStatus {
         case duplicatedNickname = "중복된 닉네임입니다. 다시 입력해주세요."
-        case invalidNicknameFormat = "닉네임 입력 조건을 확인해주세요."
+        case invalidNicknameFormat = "한글 최소 2자 이상 입력해주세요."
         
         var message: String { rawValue }
         var isError: Bool { true }

--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Manager/TokenManager.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Manager/TokenManager.swift
@@ -26,6 +26,11 @@ final class TokenManager {
         set { keychain["refreshToken"] = newValue }
     }
     
+    var signupAccessToken: String? {
+        get { return keychain["signupAccessToken"] }
+        set { keychain["signupAccessToken"] = newValue }
+    }
+    
     var identityToken: String? {
         get { return keychain["identityToken"] }
         set { keychain["identityToken"] = newValue }
@@ -49,6 +54,7 @@ final class TokenManager {
     var hasAccessToken: Bool { return self.accessToken != nil }
     var accessTokenValue: String { return self.accessToken ?? "" }
     var refreshTokenValue: String { return self.refreshToken ?? "" }
+    var signupAccessTokenValue: String { return self.signupAccessToken ?? "" }
     var identityTokenValue: String { return self.identityToken ?? "" }
     var platformValue: String { return self.platform ?? "" }
     var fcmTokenValue: String { return self.fcmToken ?? "" }
@@ -66,7 +72,7 @@ extension TokenManager {
         self.refreshToken = refreshToken
     }
     
-    func reissueToken(completion: @escaping (Bool) -> Void) {        
+    func reissueToken(completion: @escaping (Bool) -> Void) {
         Providers.authProvider.request(
             target: .patchReissue,
             instance: BaseResponse<PatchReissueResponse>.self
@@ -89,9 +95,14 @@ extension TokenManager {
         self.fcmToken = fcmToken
     }
     
+    func updateSignupAccessToken(_ accessToken: String) {
+        self.signupAccessToken = accessToken
+    }
+    
     func clearAll() {
         self.accessToken = nil
         self.refreshToken = nil
+        self.signupAccessToken = nil
         self.identityToken = nil
         self.platform = nil
     }

--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Manager/TokenManager.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Manager/TokenManager.swift
@@ -26,11 +26,6 @@ final class TokenManager {
         set { keychain["refreshToken"] = newValue }
     }
     
-    var signupAccessToken: String? {
-        get { return keychain["signupAccessToken"] }
-        set { keychain["signupAccessToken"] = newValue }
-    }
-    
     var identityToken: String? {
         get { return keychain["identityToken"] }
         set { keychain["identityToken"] = newValue }
@@ -54,7 +49,6 @@ final class TokenManager {
     var hasAccessToken: Bool { return self.accessToken != nil }
     var accessTokenValue: String { return self.accessToken ?? "" }
     var refreshTokenValue: String { return self.refreshToken ?? "" }
-    var signupAccessTokenValue: String { return self.signupAccessToken ?? "" }
     var identityTokenValue: String { return self.identityToken ?? "" }
     var platformValue: String { return self.platform ?? "" }
     var fcmTokenValue: String { return self.fcmToken ?? "" }
@@ -95,14 +89,9 @@ extension TokenManager {
         self.fcmToken = fcmToken
     }
     
-    func updateSignupAccessToken(_ accessToken: String) {
-        self.signupAccessToken = accessToken
-    }
-    
     func clearAll() {
         self.accessToken = nil
         self.refreshToken = nil
-        self.signupAccessToken = nil
         self.identityToken = nil
         self.platform = nil
     }

--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Manager/TokenManager.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Manager/TokenManager.swift
@@ -26,7 +26,10 @@ final class TokenManager {
         set { keychain["refreshToken"] = newValue }
     }
     
-    var authCode: String?
+    var signupAccessToken: String? {
+        get { return keychain["signupAccessToken"] }
+        set { keychain["signupAccessToken"] = newValue }
+    }
     
     var identityToken: String? {
         get { return keychain["identityToken"] }
@@ -51,7 +54,7 @@ final class TokenManager {
     var hasAccessToken: Bool { return self.accessToken != nil }
     var accessTokenValue: String { return self.accessToken ?? "" }
     var refreshTokenValue: String { return self.refreshToken ?? "" }
-    var authCodeValue: String { return self.authCode ?? "" }
+    var signupAccessTokenValue: String { return self.signupAccessToken ?? "" }
     var identityTokenValue: String { return self.identityToken ?? "" }
     var platformValue: String { return self.platform ?? "" }
     var fcmTokenValue: String { return self.fcmToken ?? "" }
@@ -92,9 +95,14 @@ extension TokenManager {
         self.fcmToken = fcmToken
     }
     
+    func updateSignupAccessToken(_ accessToken: String) {
+        self.signupAccessToken = accessToken
+    }
+    
     func clearAll() {
         self.accessToken = nil
         self.refreshToken = nil
+        self.signupAccessToken = nil
         self.identityToken = nil
         self.platform = nil
     }

--- a/Gongbaek_iOS/Gongbaek_iOS/Network/Base/NetworkProvider.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Network/Base/NetworkProvider.swift
@@ -20,37 +20,16 @@ class NetworkProvider<Provider : TargetType> : MoyaProvider<Provider> {
             switch result {
             case .success(let response):
                 if (200..<300).contains(response.statusCode) {
-                    if let decodeData = try? JSONDecoder().decode(instance, from: response.data) {
-                        completion(decodeData)
-                    } else{
-                        print("🚨 decoding Error 발생")
-                        /// 알 수 없는 오류
-                        let errorResponse = BaseResponse<Model>(
-                            success: false,
-                            code: 0,
-                            message: "",
-                            data: nil
-                        )
-                        completion(errorResponse)
-                    }
+                    let decodedResponse = self.decodeOrFallbackData(instance, from: response.data)
+                    completion(decodedResponse)
                 } else {
                     print("🚨 Client Error")
                 }
                 
+            /// 400-500 에러
             case .failure(let error):
                 if let response = error.response {
-                    /// 400-500 에러
-                    let decodedResponse = BaseResponse<Model>(
-                        success: false,
-                        code: response.statusCode,
-                        message: "",
-                        data: nil
-                    )
-                    if let responseData = String(data: response.data, encoding: .utf8) {
-                        print(responseData)
-                    } else {
-                        print(error.localizedDescription)
-                    }
+                    let decodedResponse = self.decodeOrFallbackData(instance, from: response.data)
                     completion(decodedResponse)
                 } else {
                     /// 네트워크 오류
@@ -64,6 +43,26 @@ class NetworkProvider<Provider : TargetType> : MoyaProvider<Provider> {
                     print(error.localizedDescription)
                 }
             }
+        }
+    }
+}
+
+extension NetworkProvider {
+    
+    func decodeOrFallbackData<Model: Codable>(
+        _ type: BaseResponse<Model>.Type,
+        from data: Data
+    ) -> BaseResponse<Model> {
+        if let decodedData = try? JSONDecoder().decode(type, from: data) {
+            return decodedData
+        } else {
+            print("🚨 Decoding Error 발생")
+            return BaseResponse<Model>(
+                success: false,
+                code: 0,
+                message: "",
+                data: nil
+            )
         }
     }
 }

--- a/Gongbaek_iOS/Gongbaek_iOS/Network/Environment/APIConstants.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Network/Environment/APIConstants.swift
@@ -39,9 +39,4 @@ extension APIConstants {
         contentType: applicationJSON,
         auth: TokenManager.shared.refreshTokenValue
     ]
-    
-    static let signupAccessTokenHeader: [String: String] = [
-        contentType: applicationJSON,
-        auth: Bearer + TokenManager.shared.signupAccessTokenValue
-    ]
 }

--- a/Gongbaek_iOS/Gongbaek_iOS/Network/Environment/APIConstants.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Network/Environment/APIConstants.swift
@@ -17,17 +17,11 @@ struct APIConstants{
     static let refresh = "refreshToken"
     static let accessToken = "Bearer " + ""
     static let refreshToken = "Bearer " + ""
-    static var authCode = ""
     static let Bearer = "Bearer "
 }
 
 extension APIConstants {
-    static let authCodeHeader: [String: String] = [
-        contentType: applicationJSON,
-        auth: Bearer + authCode
-    ]
-    
-    static let hasContentTypeHeader: [String: String] = [
+    static let contentTypeHeader: [String: String] = [
         contentType: applicationJSON
     ]
     
@@ -44,5 +38,10 @@ extension APIConstants {
     static var refreshTokenHeader: [String: String] = [
         contentType: applicationJSON,
         auth: TokenManager.shared.refreshTokenValue
+    ]
+    
+    static let signupAccessTokenHeader: [String: String] = [
+        contentType: applicationJSON,
+        auth: Bearer + TokenManager.shared.signupAccessTokenValue
     ]
 }

--- a/Gongbaek_iOS/Gongbaek_iOS/Network/Environment/APIConstants.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Network/Environment/APIConstants.swift
@@ -27,7 +27,7 @@ extension APIConstants {
     
     static var appleAuthHeader: [String: String] {
         [contentType: applicationJSON,
-            auth: TokenManager.shared.identityTokenValue]
+                auth: TokenManager.shared.identityTokenValue]
     }
     
     static var accessTokenHeader: [String: String] {
@@ -39,9 +39,9 @@ extension APIConstants {
         [contentType: applicationJSON,
                 auth: Bearer + TokenManager.shared.refreshTokenValue]
     }
-  
-    static let signupAccessTokenHeader: [String: String] = [
-        contentType: applicationJSON,
-        auth: Bearer + TokenManager.shared.signupAccessTokenValue
-    ]
+
+    static var signupAccessTokenHeader: [String: String] {
+        [contentType: applicationJSON,
+                auth: Bearer + TokenManager.shared.signupAccessTokenValue]
+    }
 }

--- a/Gongbaek_iOS/Gongbaek_iOS/Network/Environment/APIConstants.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Network/Environment/APIConstants.swift
@@ -39,4 +39,9 @@ extension APIConstants {
         contentType: applicationJSON,
         auth: TokenManager.shared.refreshTokenValue
     ]
+    
+    static let signupAccessTokenHeader: [String: String] = [
+        contentType: applicationJSON,
+        auth: Bearer + TokenManager.shared.signupAccessTokenValue
+    ]
 }

--- a/Gongbaek_iOS/Gongbaek_iOS/Network/Service/DTO/Signup/PostSignupRequestDTO.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Network/Service/DTO/Signup/PostSignupRequestDTO.swift
@@ -8,9 +8,11 @@
 import Foundation
 
 struct PostSignupRequestDTO: Codable {
+    let platform: String
     let profileImg: Int
     let nickname: String
     let mbti: String
+    let email: String
     let schoolName: String
     let schoolMajor: String
     let enterYear: Int

--- a/Gongbaek_iOS/Gongbaek_iOS/Network/Service/TargetType/SignupTargetType.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Network/Service/TargetType/SignupTargetType.swift
@@ -12,19 +12,22 @@ enum SignupTargetType {
     case getSchoolSearchResults(schoolName: String)
     case getMajorSearchResults(schoolName: String, majorName: String)
     case postSignup(data: PostSignupRequestDTO)
+    case postSendEmailVerificationCode(email: String, schoolName: String)
 }
 
 extension SignupTargetType: BaseTargetType {
     var headers: Parameters? {
         switch self {
         case .postNicknameValidation:
-            return APIConstants.hasContentTypeHeader
+            return APIConstants.contentTypeHeader
         case .getSchoolSearchResults:
-            return APIConstants.hasContentTypeHeader
+            return APIConstants.contentTypeHeader
         case .getMajorSearchResults:
-            return APIConstants.hasContentTypeHeader
+            return APIConstants.contentTypeHeader
         case .postSignup:
-            return APIConstants.hasContentTypeHeader
+            return APIConstants.contentTypeHeader
+        case .postSendEmailVerificationCode:
+            return APIConstants.signupAccessTokenHeader
         }
     }
     
@@ -38,6 +41,8 @@ extension SignupTargetType: BaseTargetType {
             return "/api/v1/school/major/search"
         case .postSignup:
             return "/api/v1/user/signup"
+        case .postSendEmailVerificationCode:
+            return "/api/v1/school"
         }
     }
     
@@ -50,6 +55,8 @@ extension SignupTargetType: BaseTargetType {
         case .getMajorSearchResults:
             return .get
         case .postSignup:
+            return .post
+        case .postSendEmailVerificationCode:
             return .post
         }
     }
@@ -76,6 +83,14 @@ extension SignupTargetType: BaseTargetType {
             )
         case .postSignup(let data):
             return .requestJSONEncodable(data)
+        case .postSendEmailVerificationCode(let email, let schoolName):
+            return .requestParameters(
+                parameters: [
+                    "email" : email,
+                    "schoolName" : schoolName,
+                ],
+                encoding: URLEncoding.queryString
+            )
         }
     }
 }

--- a/Gongbaek_iOS/Gongbaek_iOS/Network/Service/TargetType/SignupTargetType.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Network/Service/TargetType/SignupTargetType.swift
@@ -26,7 +26,7 @@ extension SignupTargetType: BaseTargetType {
         case .getMajorSearchResults:
             return APIConstants.contentTypeHeader
         case .postSignup:
-            return APIConstants.contentTypeHeader
+            return APIConstants.signupAccessTokenHeader
         case .postSendEmailVerificationCode:
             return APIConstants.contentTypeHeader
         case .getSchoolEmailVerification:

--- a/Gongbaek_iOS/Gongbaek_iOS/Network/Service/TargetType/SignupTargetType.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Network/Service/TargetType/SignupTargetType.swift
@@ -13,6 +13,7 @@ enum SignupTargetType {
     case getMajorSearchResults(schoolName: String, majorName: String)
     case postSignup(data: PostSignupRequestDTO)
     case postSendEmailVerificationCode(email: String, schoolName: String)
+//    case postVeritySchoolEmailCode(code: String)
 }
 
 extension SignupTargetType: BaseTargetType {
@@ -27,7 +28,7 @@ extension SignupTargetType: BaseTargetType {
         case .postSignup:
             return APIConstants.contentTypeHeader
         case .postSendEmailVerificationCode:
-            return APIConstants.signupAccessTokenHeader
+            return APIConstants.contentTypeHeader
         }
     }
     
@@ -42,7 +43,7 @@ extension SignupTargetType: BaseTargetType {
         case .postSignup:
             return "/api/v1/user/signup"
         case .postSendEmailVerificationCode:
-            return "/api/v1/school"
+            return "/api/v1/emails/verification-requests"
         }
     }
     

--- a/Gongbaek_iOS/Gongbaek_iOS/Network/Service/TargetType/SignupTargetType.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Network/Service/TargetType/SignupTargetType.swift
@@ -13,7 +13,7 @@ enum SignupTargetType {
     case getMajorSearchResults(schoolName: String, majorName: String)
     case postSignup(data: PostSignupRequestDTO)
     case postSendEmailVerificationCode(email: String, schoolName: String)
-//    case postVeritySchoolEmailCode(code: String)
+    case getSchoolEmailVerification(email: String, schoolName: String, code: String)
 }
 
 extension SignupTargetType: BaseTargetType {
@@ -28,6 +28,8 @@ extension SignupTargetType: BaseTargetType {
         case .postSignup:
             return APIConstants.contentTypeHeader
         case .postSendEmailVerificationCode:
+            return APIConstants.contentTypeHeader
+        case .getSchoolEmailVerification:
             return APIConstants.contentTypeHeader
         }
     }
@@ -44,6 +46,8 @@ extension SignupTargetType: BaseTargetType {
             return "/api/v1/user/signup"
         case .postSendEmailVerificationCode:
             return "/api/v1/emails/verification-requests"
+        case .getSchoolEmailVerification:
+            return "/api/v1/emails/verifications"
         }
     }
     
@@ -59,6 +63,8 @@ extension SignupTargetType: BaseTargetType {
             return .post
         case .postSendEmailVerificationCode:
             return .post
+        case .getSchoolEmailVerification:
+            return .get
         }
     }
     
@@ -89,6 +95,15 @@ extension SignupTargetType: BaseTargetType {
                 parameters: [
                     "email" : email,
                     "schoolName" : schoolName,
+                ],
+                encoding: URLEncoding.queryString
+            )
+        case .getSchoolEmailVerification(let email, let schoolName, let code):
+            return .requestParameters(
+                parameters: [
+                    "email" : email,
+                    "schoolName" : schoolName,
+                    "code" : code,
                 ],
                 encoding: URLEncoding.queryString
             )

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Login/LoginViewModel.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Login/LoginViewModel.swift
@@ -44,7 +44,9 @@ class LoginViewModel: NSObject, ObservableObject {
                     TokenManager.shared.updateToken(data.accessToken, data.refreshToken)
                     self.loginFlow = .existingUser
                 } else {
-                    // 신규 유저 -> 아직 회원가입 미완료 → 약관 동의로, 토큰 저장 X
+                    // 신규 유저 -> 아직 회원가입 미완료 → 약관 동의로
+                    // **회원가입 전 학교 이메일 인증에 액세스 토큰 필요하여 키체인에 저장**
+                    TokenManager.shared.updateSignupAccessToken(data.accessToken)
                     self.loginFlow = .newUser
                 }
             }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Login/LoginViewModel.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Login/LoginViewModel.swift
@@ -44,9 +44,7 @@ class LoginViewModel: NSObject, ObservableObject {
                     TokenManager.shared.updateToken(data.accessToken, data.refreshToken)
                     self.loginFlow = .existingUser
                 } else {
-                    // 신규 유저 -> 아직 회원가입 미완료 → 약관 동의로
-                    // **회원가입 전 학교 이메일 인증에 액세스 토큰 필요하여 키체인에 저장**
-                    TokenManager.shared.updateSignupAccessToken(data.accessToken)
+                    // 신규 유저 -> 아직 회원가입 미완료 → 약관 동의로, 토큰 저장 X
                     self.loginFlow = .newUser
                 }
             }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Login/LoginViewModel.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Login/LoginViewModel.swift
@@ -44,7 +44,9 @@ class LoginViewModel: NSObject, ObservableObject {
                     TokenManager.shared.updateToken(data.accessToken, data.refreshToken)
                     self.loginFlow = .existingUser
                 } else {
-                    // 신규 유저 -> 아직 회원가입 미완료 → 약관 동의로 토큰 저장 X
+                    // 신규 유저 -> 아직 회원가입 미완료 → 약관 동의로
+                    // **회원가입 전 학교 이메일 인증에 액세스 토큰 필요하여 키체인에 저장**
+                    TokenManager.shared.updateSignupAccessToken(data.accessToken)
                     self.loginFlow = .newUser
                 }
             }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/View/SchoolEmailVerificationView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/View/SchoolEmailVerificationView.swift
@@ -52,7 +52,8 @@ struct SchoolEmailVerificationView: View {
                     )
                 
                 blackButton(title: "인증하기") {
-                    // TODO: 뷰모델 API 호출
+                    // TODO: (API 호출 전) 타이머 남은시간 확인, 텍스트필드 empty 확인
+                    viewModel.getSchoolEmailCodeVerification()
                 }
                 .disabled(viewModel.isVerifyButtonDisabled)
             }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/View/SchoolEmailVerificationView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/View/SchoolEmailVerificationView.swift
@@ -31,10 +31,9 @@ struct SchoolEmailVerificationView: View {
                 .textInputAutocapitalization(.never)
                 
                 blackButton(title: "코드받기") {
-                    // TODO: 뷰모델 API 호출
+                    // TODO: 뷰모델 API 호출 (전에 이메일 형식 확인)
                     // response 받으면 3분 타이머 시작
-                    viewModel.startTimer()
-                    isTimerVisible = true
+                    viewModel.postSendEmailVerificationCode()
                 }
             }
             .padding(.bottom, 34)
@@ -57,6 +56,7 @@ struct SchoolEmailVerificationView: View {
                 blackButton(title: "인증하기") {
                     // TODO: 뷰모델 API 호출
                 }
+                .disabled(viewModel.isVerifyButtonDisabled)
             }
             
             Spacer()

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/View/SchoolEmailVerificationView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/View/SchoolEmailVerificationView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct SchoolEmailVerificationView: View {
     @ObservedObject var viewModel: SignupViewModel
-    @State private var isTimerVisible: Bool = false
     
     var body: some View {
         VStack(spacing: 0) {
@@ -32,7 +31,6 @@ struct SchoolEmailVerificationView: View {
                 
                 blackButton(title: "코드받기") {
                     // TODO: 뷰모델 API 호출 (전에 이메일 형식 확인)
-                    // response 받으면 3분 타이머 시작
                     viewModel.postSendEmailVerificationCode()
                 }
             }
@@ -92,7 +90,7 @@ struct SchoolEmailVerificationView: View {
                 x: proxy.size.width - 16 - 15,
                 y: proxy.size.height - 48 / 2
             )
-            .opacity(isTimerVisible ? 1 : 0)
+            .opacity(viewModel.isTimerVisible ? 1 : 0)
     }
 }
 

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/View/SchoolEmailVerificationView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/View/SchoolEmailVerificationView.swift
@@ -9,7 +9,12 @@ import SwiftUI
 
 struct SchoolEmailVerificationView: View {
     @ObservedObject var viewModel: SignupViewModel
-    @State private var getCodeButtonTitle = "코드받기"
+    @State private var getCodeButtonTitle: GetCodeButtonTitle = .sendCode
+    
+    enum GetCodeButtonTitle: String {
+        case sendCode = "코드받기"
+        case resendCode = "다시받기"
+    }
     
     var body: some View {
         VStack(spacing: 0) {
@@ -27,13 +32,14 @@ struct SchoolEmailVerificationView: View {
                     status: $viewModel.emailStatus,
                     type: .schoolEmail
                 )
-                .autocorrectionDisabled(true)
-                .textInputAutocapitalization(.never)
                 
-                blackButton(title: getCodeButtonTitle) {
+                blackButton(title: getCodeButtonTitle.rawValue) {
+                    viewModel.emailStatus = nil
+                    
                     if viewModel.isValidEmailFormat() {
                         viewModel.postSendEmailVerificationCode()
-                        getCodeButtonTitle = "다시받기"
+                        getCodeButtonTitle = .resendCode
+                        viewModel.verificationStatus = nil
                     } else {
                         viewModel.emailStatus = .invalidEmailFormat
                     }
@@ -48,8 +54,6 @@ struct SchoolEmailVerificationView: View {
                         status: $viewModel.verificationStatus,
                         type: .verificationCode
                     )
-                    .autocorrectionDisabled(true)
-                    .textInputAutocapitalization(.never)
                     .keyboardType(.numberPad)
                     .overlay(
                         GeometryReader { proxy in
@@ -58,8 +62,10 @@ struct SchoolEmailVerificationView: View {
                     )
                 
                 blackButton(title: "인증하기") {
-                    // TODO: (API 호출 전) 타이머 status 만료된건지 확인, 텍스트필드 empty 확인
-                    viewModel.getSchoolEmailCodeVerification()
+                    if viewModel.verificationStatus != .expiredCode,
+                       !viewModel.verificationCode.isEmpty {
+                        viewModel.getSchoolEmailCodeVerification()
+                    }
                 }
                 .disabled(viewModel.isVerifyButtonDisabled)
             }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/View/SchoolEmailVerificationView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/View/SchoolEmailVerificationView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct SchoolEmailVerificationView: View {
     @ObservedObject var viewModel: SignupViewModel
+    @State private var getCodeButtonTitle = "코드받기"
     
     var body: some View {
         VStack(spacing: 0) {
@@ -29,10 +30,12 @@ struct SchoolEmailVerificationView: View {
                 .autocorrectionDisabled(true)
                 .textInputAutocapitalization(.never)
                 
-                blackButton(title: "코드받기") {
+                blackButton(title: getCodeButtonTitle) {
                     // TODO: 뷰모델 API 호출 (전에 이메일 형식 확인)
                     viewModel.postSendEmailVerificationCode()
+                    getCodeButtonTitle = "다시받기"
                 }
+                .disabled(viewModel.isGetCodeButtonDisabled)
             }
             .padding(.bottom, 34)
             

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/View/SchoolEmailVerificationView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/View/SchoolEmailVerificationView.swift
@@ -31,9 +31,12 @@ struct SchoolEmailVerificationView: View {
                 .textInputAutocapitalization(.never)
                 
                 blackButton(title: getCodeButtonTitle) {
-                    // TODO: 뷰모델 API 호출 (전에 이메일 형식 확인)
-                    viewModel.postSendEmailVerificationCode()
-                    getCodeButtonTitle = "다시받기"
+                    if viewModel.isValidEmailFormat() {
+                        viewModel.postSendEmailVerificationCode()
+                        getCodeButtonTitle = "다시받기"
+                    } else {
+                        viewModel.emailStatus = .invalidEmailFormat
+                    }
                 }
                 .disabled(viewModel.isGetCodeButtonDisabled)
             }
@@ -55,7 +58,7 @@ struct SchoolEmailVerificationView: View {
                     )
                 
                 blackButton(title: "인증하기") {
-                    // TODO: (API 호출 전) 타이머 남은시간 확인, 텍스트필드 empty 확인
+                    // TODO: (API 호출 전) 타이머 status 만료된건지 확인, 텍스트필드 empty 확인
                     viewModel.getSchoolEmailCodeVerification()
                 }
                 .disabled(viewModel.isVerifyButtonDisabled)

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/View/SignupView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/View/SignupView.swift
@@ -34,11 +34,14 @@ struct SignupView: View {
                     ? "공백 채우러 가기" : (currentStep == .classTimeTableInput ? "가입 완료" : "다음"),
                     isActivated: viewModel.isNextButtonEnabled(currentStep)
                 ) {
-                    if currentStep == .nicknameSexInput {
+                    switch currentStep {
+                    case .nicknameSexInput:
                         validateNickname()
-                    } else if currentStep == .signupCompletion {
+                    case .classTimeTableInput:
+                        signup()
+                    case .signupCompletion:
                         goToTabBarView()
-                    } else {
+                    default:
                         goToNextStep()
                     }
                 }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/View/SignupView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/View/SignupView.swift
@@ -124,7 +124,8 @@ extension SignupView {
 extension SignupView {
     
     private func validateNickname() {
-        if !viewModel.isOnlyCompleteHangulSyllables(viewModel.nickname) {
+        if !viewModel.isOnlyCompleteHangulSyllables(viewModel.nickname)
+            || viewModel.nickname.count < 2 {
             viewModel.nicknameStatus = .invalidNicknameFormat
             return
         }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/View/SignupView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/View/SignupView.swift
@@ -82,7 +82,7 @@ struct SignupView: View {
             if viewModel.showAlert {
                 CustomedAlert(
                     alertImage: "img_fail" ,
-                    titleText: "앗! 회원가입에 실패했어요.",
+                    titleText: currentStep == .classTimeTableInput ? "앗! 회원가입에 실패했어요." : "앗! 오류가 발생했어요.",
                     subtitleText: "다시 시도해주세요.",
                     orangeButtonText: "확인",
                     onTapOrangeButton: {
@@ -131,11 +131,7 @@ extension SignupView {
         
         viewModel.postNicknameValidation { isSuccess in
             if isSuccess {
-                viewModel.nicknameStatus = nil
                 goToNextStep()
-            }
-            else {
-                viewModel.nicknameStatus = .duplicatedNickname
             }
         }
     }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/ViewModel/SignupViewModel.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/ViewModel/SignupViewModel.swift
@@ -70,7 +70,7 @@ final class SignupViewModel: ObservableObject {
         case .schoolEmailVerification:
             return isEmailVerified
         case .nicknameSexInput:
-            return nickname.count > 1 && sex != nil
+            return nickname.count > 0 && sex != nil
         case .profileImageSelection:
             return profileImageIndex != nil
         case .mbtiSelection:

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/ViewModel/SignupViewModel.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/ViewModel/SignupViewModel.swift
@@ -24,9 +24,16 @@ final class SignupViewModel: ObservableObject {
     // 이메일 인증
     @Published var email = ""
     @Published var verificationCode = ""
-    @Published var isEmailVerified: Bool = true
+    @Published var isEmailVerified: Bool = false {
+        didSet {
+            isVerifyButtonDisabled = true
+            isGetCodeButtonDisabled = true
+            verificationStatus = .verificationCompleted
+        }
+    }
     @Published var emailStatus: TextFieldType.EmailStatus? = nil
     @Published var verificationStatus: TextFieldType.VerificationStatus? = nil
+    @Published var isGetCodeButtonDisabled: Bool = false
     @Published var isVerifyButtonDisabled: Bool = true
     // 타이머
     @Published var isTimerVisible = false
@@ -176,13 +183,15 @@ final class SignupViewModel: ObservableObject {
         cancellable = Timer
             .publish(every: 1, on: .main, in: .common)
             .autoconnect()
+            .filter { _ in !self.isEmailVerified }
             .sink { [weak self] _ in
                 guard let self = self else { return }
                 
-                if self.remainingTime > 0 {
-                    self.remainingTime -= 1
+                if remainingTime > 0 {
+                    remainingTime -= 1
                 } else {
-                    self.cancellable?.cancel()
+                    cancellable?.cancel()
+                    verificationStatus = .expiredCode
                 }
             }
     }
@@ -279,13 +288,13 @@ extension SignupViewModel {
             instance: BaseResponse<EmptyResponseDTO>.self
         ) { response in
             if response.success {
-//                self.showAlert = true
-                // TODO: 회원가입 api 호출하는 화면인지에 따라 alert 내용 바꿔야 할듯...
                 self.startTimer()
                 self.isTimerVisible = true
+                self.emailStatus = .codeSent
                 self.isVerifyButtonDisabled = false
             } else {
-                
+//                self.showAlert = true
+                // TODO: 회원가입 api 호출하는 화면인지에 따라 alert 내용 바꿔야 할듯...
             }
         }
     }
@@ -303,7 +312,10 @@ extension SignupViewModel {
             if response.success {
                 self.isEmailVerified = true
             } else {
-                
+                switch response.code {
+                case 4001: self.verificationStatus = .invalidCode
+                default: self.showAlert = true // TODO: Alert 내용 변경
+                }
             }
         }
     }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/ViewModel/SignupViewModel.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/ViewModel/SignupViewModel.swift
@@ -234,21 +234,20 @@ extension SignupViewModel {
             instance: BaseResponse<EmptyResponseDTO>.self
         ) { response in
             if response.success {
-                self.showAlert = false
+                self.nicknameStatus = nil
                 completion(true)
             } else {
-                print(response.code,"🚨")
                 switch response.code {
-                case 409:
-                    /// 닉네임 중복 에러
-                    self.showAlert = false
+                case 4006:
+                    /// 한글 이외 문자 입력 에러
+                    self.nicknameStatus = .invalidNicknameFormat
                     completion(false)
-                case 400..<500:
-                    self.showAlert = false
-                    print(response.message ?? "❗️유효하지 않은 요청")
+                case 4092:
+                    /// 닉네임 중복 에러
+                    self.nicknameStatus = .duplicatedNickname
+                    completion(false)
                 default:
                     self.showAlert = true
-                    print("❗️서버 통신 에러 발생")
                 }
             }
         }
@@ -262,7 +261,6 @@ extension SignupViewModel {
         ) { response in
             print(response)
             if response.success {
-                self.showAlert = false
                 guard let data = response.data else { return }
                 self.searchResultList = data.schoolNames
             } else {
@@ -282,7 +280,6 @@ extension SignupViewModel {
         ) { response in
             print(response)
             if response.success {
-                self.showAlert = false
                 guard let data = response.data else { return }
                 self.searchResultList = data.schoolMajors
             } else {
@@ -303,8 +300,7 @@ extension SignupViewModel {
                 self.emailStatus = .codeSent
                 self.isVerifyButtonDisabled = false
             } else {
-//                self.showAlert = true
-                // TODO: alert 내용 바꿔야 할듯...
+                self.showAlert = true
             }
         }
     }
@@ -322,7 +318,10 @@ extension SignupViewModel {
             if response.success {
                 self.isEmailVerified = true
             } else {
-                self.verificationStatus = .invalidCode
+                switch response.code {
+                case 4001: self.verificationStatus = .invalidCode
+                default: self.showAlert = true
+                }
             }
         }
     }
@@ -355,7 +354,6 @@ extension SignupViewModel {
             instance: BaseResponse<PostSignupResponseDTO>.self
         ) { response in
             if response.success {
-                self.showAlert = false
                 guard let accessToken = response.data?.accessToken,
                       let refreshToken = response.data?.refreshToken
                 else { return }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/ViewModel/SignupViewModel.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/ViewModel/SignupViewModel.swift
@@ -26,9 +26,11 @@ final class SignupViewModel: ObservableObject {
     @Published var verificationCode = ""
     @Published var isEmailVerified: Bool = false {
         didSet {
-            isVerifyButtonDisabled = true
-            isGetCodeButtonDisabled = true
-            verificationStatus = .verificationCompleted
+            if isEmailVerified {
+                isVerifyButtonDisabled = true
+                isGetCodeButtonDisabled = true
+                verificationStatus = .verificationCompleted
+            }
         }
     }
     @Published var emailStatus: TextFieldType.EmailStatus? = nil
@@ -59,7 +61,6 @@ final class SignupViewModel: ObservableObject {
     // 에러
     @Published var showAlert: Bool = false
 
-    
     // MARK: - Methods
     
     func isNextButtonEnabled(_ step: SignupStep) -> Bool {
@@ -100,9 +101,13 @@ final class SignupViewModel: ObservableObject {
             yearOfAdmission = nil
         case .schoolEmailVerification:
             email = ""
+            verificationCode = ""
             isEmailVerified = false
             emailStatus = nil
             verificationStatus = nil
+            isTimerVisible = false
+            isGetCodeButtonDisabled = false
+            isVerifyButtonDisabled = true
         case .nicknameSexInput:
             nickname = ""
             sex = nil
@@ -299,7 +304,7 @@ extension SignupViewModel {
                 self.isVerifyButtonDisabled = false
             } else {
 //                self.showAlert = true
-                // TODO: 회원가입 api 호출하는 화면인지에 따라 alert 내용 바꿔야 할듯...
+                // TODO: alert 내용 바꿔야 할듯...
             }
         }
     }
@@ -317,10 +322,7 @@ extension SignupViewModel {
             if response.success {
                 self.isEmailVerified = true
             } else {
-                switch response.code {
-                case 4001: self.verificationStatus = .invalidCode
-                default: self.showAlert = true // TODO: Alert 내용 변경
-                }
+                self.verificationStatus = .invalidCode
             }
         }
     }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/ViewModel/SignupViewModel.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/ViewModel/SignupViewModel.swift
@@ -27,7 +27,9 @@ final class SignupViewModel: ObservableObject {
     @Published var isEmailVerified: Bool = true
     @Published var emailStatus: TextFieldType.EmailStatus? = nil
     @Published var verificationStatus: TextFieldType.VerificationStatus? = nil
+    @Published var isVerifyButtonDisabled: Bool = true
     // 타이머
+    @Published var isTimerVisible = false
     private let totalSeconds: Int = 180
     @Published var remainingTime: Int = 0
     private var cancellable: AnyCancellable?
@@ -268,17 +270,42 @@ extension SignupViewModel {
         }
     }
     
+    /// 학교 이메일 인증코드 전송 API
+    func postSendEmailVerificationCode() {
+        // TODO: 이메일 정규식 검사(학교 이메일 형식 다양한 걸로 테스트 필수)
+        
+        Providers.SignupProvider.request(
+            target: .postSendEmailVerificationCode(email: email, schoolName: schoolName),
+            instance: BaseResponse<EmptyResponseDTO>.self
+        ) { response in
+            if response.success {
+//                self.showAlert = true
+                // TODO: 회원가입 api 호출하는 화면인지에 따라 alert 내용 바꿔야 할듯...
+                self.startTimer()
+                self.isTimerVisible = true
+                self.isVerifyButtonDisabled = false
+            } else {
+                
+            }
+        }
+    }
+    
+    /// 학교 이메일 인증  API
+    func postVerifySchoolEmailCode() {
+        
+    }
+    
     /// 회원가입 API
     func postSignup(completion: @escaping (Bool) -> ()) {
-        guard let profileImage = profileImageIndex,
-              let yearOfAdmission = yearOfAdmission,
-              let e_i, let s_n, let t_f, let j_p,
-              let sex = sex
+        guard let yearOfAdmission = yearOfAdmission,
+              let sex = sex,
+              let profileImage = profileImageIndex,
+              let e_i, let s_n, let t_f, let j_p
         else { return }
         saveSelectedCellsToClassTimeTable()
         
         let data = PostSignupRequestDTO(
-            profileImg: profileImage + 1,
+            profileImg: profileImage,
             nickname: nickname,
             mbti: e_i.rawValue + s_n.rawValue + t_f.rawValue + j_p.rawValue,
             schoolName: schoolName,

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/ViewModel/SignupViewModel.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/ViewModel/SignupViewModel.swift
@@ -206,6 +206,13 @@ final class SignupViewModel: ObservableObject {
         return String(format: "%02d:%02d", minutes, seconds)
     }
     
+    /// 이메일 형식 정규식 검사
+    func isValidEmailFormat() -> Bool {
+        let regex = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"
+        let predicate = NSPredicate(format: "SELF MATCHES %@", regex)
+        return predicate.evaluate(with: email)
+    }
+    
     /// 완전한 한글 음절로만 이루어져 있는지 확인
     func isOnlyCompleteHangulSyllables(_ text: String) -> Bool {
         let regex = try! NSRegularExpression(pattern: "^[가-힣]+$")
@@ -281,8 +288,6 @@ extension SignupViewModel {
     
     /// 학교 이메일 인증코드 전송 API
     func postSendEmailVerificationCode() {
-        // TODO: 이메일 정규식 검사(학교 이메일 형식 다양한 걸로 테스트 필수)
-        
         Providers.SignupProvider.request(
             target: .postSendEmailVerificationCode(email: email, schoolName: schoolName),
             instance: BaseResponse<EmptyResponseDTO>.self

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/ViewModel/SignupViewModel.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/ViewModel/SignupViewModel.swift
@@ -291,8 +291,21 @@ extension SignupViewModel {
     }
     
     /// 학교 이메일 인증  API
-    func postVerifySchoolEmailCode() {
-        
+    func getSchoolEmailCodeVerification() {
+        Providers.SignupProvider.request(
+            target: .getSchoolEmailVerification(
+                email: email,
+                schoolName: schoolName,
+                code: verificationCode
+            ),
+            instance: BaseResponse<EmptyResponseDTO>.self
+        ) { response in
+            if response.success {
+                self.isEmailVerified = true
+            } else {
+                
+            }
+        }
     }
     
     /// 회원가입 API

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/ViewModel/SignupViewModel.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/ViewModel/SignupViewModel.swift
@@ -318,9 +318,11 @@ extension SignupViewModel {
         saveSelectedCellsToClassTimeTable()
         
         let data = PostSignupRequestDTO(
+            platform: PlatformType.APPLE.rawValue,
             profileImg: profileImage,
             nickname: nickname,
             mbti: e_i.rawValue + s_n.rawValue + t_f.rawValue + j_p.rawValue,
+            email: email,
             schoolName: schoolName,
             schoolMajor: majorName,
             enterYear: yearOfAdmission,

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/ViewModel/SignupViewModel.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/ViewModel/SignupViewModel.swift
@@ -76,7 +76,7 @@ final class SignupViewModel: ObservableObject {
         case .mbtiSelection:
             return e_i != nil && s_n != nil && t_f != nil && j_p != nil
         case .selfIntroductionWriting:
-            return introduction.count >= 20
+            return introduction.count >= 0
         case .classTimeTableInput:
             return !selectedCells.isEmpty
         case .signupCompletion:

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/ViewModel/SignupViewModel.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/ViewModel/SignupViewModel.swift
@@ -76,7 +76,7 @@ final class SignupViewModel: ObservableObject {
         case .mbtiSelection:
             return e_i != nil && s_n != nil && t_f != nil && j_p != nil
         case .selfIntroductionWriting:
-            return introduction.count >= 0
+            return introduction.count > 0
         case .classTimeTableInput:
             return !selectedCells.isEmpty
         case .signupCompletion:


### PR DESCRIPTION
## 🧩 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 학교 이메일 인증코드 발송 API 연결
- 인증코드 검증 API 연결
- 회원가입용 액세스 토큰 저장 및 회원가입 API 수정사항 구현
- 이메일 정규식 검사
- UseCase별 에러 대응
- 최소 글자수 조건 수정 (닉네임, 소개글)
- 서버에서 내려주는 응답 code 그대로 사용할 수 있도록 Moya `NetworkProvider` 수정

## 🪁 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
### 1️⃣ 회원가입할 때 액세스 토큰이 필요하더라구요..
- 토큰 매니저에 `signupAccessToken` 회원가입용 액세스 토큰 만들어놨어요...! 
- 사실 서버에서 그냥 액세스 토큰 내려주는 거랑 똑같은 거임. 근데 자동로그인 로직을 위해 구분해서 처리하는 게 편하다고 판단함!!

### 2️⃣ NetworkProvider를 수정해서 이제 서버 응답코드(네자리)를 그대로 쓸 수 있음!
#### 문제점🐽: 서버에서 응답코드를 4자리로 내려주는데 (eg. 4092) 통신 실패한 경우엔 그걸 쓸 수 없었음.. 
- 세자리밖에 못 써서 세세한 에러 처리가 불가능했다능 ㅜ
<img width="383" alt="image" src="https://github.com/user-attachments/assets/945040cc-377b-4b44-8910-635e435496c9" />

#### 원인⛑️: 왜냐면 기존 NetworkProvider 코드에서는 통신 실패 처리됐을 때, 우리는 그 응답 데이터를 디코딩하지 않고...
- 모야에서 내려주는 `response.statusCode`(http 상태 코드: 3자리)로 직접 응답 모델(BaseResponse)을 만들어줬기 때문.
- 서버는 http 상태코드를 409로 설정해놓고(이게 모야가 받는 상태코드), 클라에게 보내는 response 모델 code에는 4092로 보내줌!
- 여튼 결론은 실패했을 때도 response가 오기만 한다면,, 그 데이터를 디코딩만 해주면 네자리 응답 코드 쓸 수 있음! 안해줘서 못 쓴것뿐.
<img width="821" alt="image" src="https://github.com/user-attachments/assets/e9d6786a-fffb-48ad-98b6-0e89234e89b2" />

#### 해결☀️: 전에는 통신 성공(200)일 때만 데이터를 디코딩했는데, 지금은 실패해도 응답 데이터를 디코딩합니다! 
- 그래서 그 디코딩된 데이터를 completion 클로저로 넘기기 때문에 각자의 뷰모델에서 다 네자리 응답코드 쓸 수 있슴다😀
---
## 🪽 결론
<img width="746" alt="image" src="https://github.com/user-attachments/assets/171dbd2d-aebe-4800-8fb7-2368995bf558" />



## 📱 스크린샷
<!-- 작업 내용, 스크린 샷(GIF/MP4) 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 이메일 유효성 검증 실패 | <img src = "https://github.com/user-attachments/assets/d8b258d3-1732-405b-8751-f655eaacaa6d" width ="300">|
| 인증번호 발송 및 타이머 시작 | <img src = "https://github.com/user-attachments/assets/9c8d276a-c12f-46a2-b5a6-11acc81fc805" width ="300">|
| 인증코드 검증 실패 | <img src = "https://github.com/user-attachments/assets/7d14b5ee-b4fc-4a44-9edc-87a4ecd019b8" width ="300">|
| 인증시간 초과 | <img src = "https://github.com/user-attachments/assets/45351694-93e9-4a98-8d62-25fc55d65299" width ="300">|
| 이메일 인증 완료 | <img src = "https://github.com/user-attachments/assets/19975bd2-fbb5-42a6-b61c-c0eb7c62cc47" width ="300">|


### 🔗 Issue 
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #25
