### PR TITLE
[Chore] #12 - 내비게이션 바 UI 수정 및 내비게이션 매니저 싱글톤 패턴으로 변경

### DIFF
--- a/Gongbaek_iOS/Gongbaek_iOS/Application/Gongbaek_iOSApp.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Application/Gongbaek_iOSApp.swift
@@ -9,20 +9,19 @@ import SwiftUI
 
 @main
 struct Gongbaek_iOSApp: App {
-    @StateObject private var navigationManager = NavigationManager()
     @State private var showMainView = false
 
     var body: some Scene {
         WindowGroup {
             if showMainView {
                 RootViewSwitcher()
-                    .environmentObject(navigationManager)
+                    .environmentObject(NavigationManager.shared)
             } else {
                 SplashView()
                     .onAppear {
                         DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
                             if TokenManager.shared.hasAccessToken {
-                                navigationManager.rootView = .tabBar
+                                NavigationManager.shared.rootView = .tabBar
                             }
                             withAnimation {
                                 showMainView = true

--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Component/Bar/Common/CustomNavigationBar.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Component/Bar/Common/CustomNavigationBar.swift
@@ -7,15 +7,29 @@
 
 import SwiftUI
 
+enum NavigationBarRightButtonType {
+    case x
+    case setting
+    case report
+    
+    var image: ImageResource {
+        switch self {
+        case .x: .icX48
+        case .setting: .icSetting48
+        case .report: .icReport48
+        }
+    }
+}
+
 struct CustomNavigationBarModifier: ViewModifier {
     @EnvironmentObject var navigationManager: NavigationManager
-    @Environment(\.dismiss) private var dismiss
     let isMeetingRoom: Bool
     let title: String?
     let viewName: String?
     let showBackButton: Bool
-    let showXButton: Bool
     let onBackButtonTap: (() -> Void)?
+    let rightButtonType: NavigationBarRightButtonType?
+    let onRightButtonTap: (() -> Void)?
     
     func body(content: Content) -> some View {
         if isMeetingRoom == true {
@@ -31,7 +45,6 @@ struct CustomNavigationBarModifier: ViewModifier {
                     .frame(height: 48)
                     .background(.clear)
                 }
-                
             }
         } else {
             VStack {
@@ -60,7 +73,7 @@ struct CustomNavigationBarModifier: ViewModifier {
                         navigationManager.pop()
                     }
                 }) {
-                    HStack(spacing: 4) {
+                    HStack(alignment: .center, spacing: 4) {
                         Image(.icArrowLeft48)
                             .frame(width: 48, height: 48)
                         if let viewName = viewName {
@@ -74,9 +87,10 @@ struct CustomNavigationBarModifier: ViewModifier {
             
             Spacer()
             
-            if showXButton {
-                Button(action: { dismiss() }) {
-                    Image(.icX48)
+            if let rightButtonType,
+               let onRightButtonTap {
+                Button(action: { onRightButtonTap() }) {
+                    Image(rightButtonType.image)
                         .frame(width: 48, height: 48)
                 }
             }

--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Component/Bar/Common/CustomNavigationBar.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Component/Bar/Common/CustomNavigationBar.swift
@@ -47,7 +47,7 @@ struct CustomNavigationBarModifier: ViewModifier {
                 }
             }
         } else {
-            VStack {
+            VStack(spacing: 0) {
                 VStack(spacing: 0) {
                     ZStack {
                         leftRightButtons()

--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Extension/View+.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Extension/View+.swift
@@ -14,15 +14,18 @@ extension View {
         title: String? = nil,
         viewName: String? = nil,
         showBackButton: Bool = false,
-        showXButton: Bool = false,
-        onBackButtonTap: (() -> Void)? = nil
+        onBackButtonTap: (() -> Void)? = nil,
+        rightButtonType: NavigationBarRightButtonType? = nil,
+        onRightButtonTap: (() -> Void)? = nil
     ) -> some View {
         self.modifier(CustomNavigationBarModifier(
-            isMeetingRoom: isMeetingRoom, title: title,
+            isMeetingRoom: isMeetingRoom,
+            title: title,
             viewName: viewName,
             showBackButton: showBackButton,
-            showXButton: showXButton,
-            onBackButtonTap: onBackButtonTap
+            onBackButtonTap: onBackButtonTap,
+            rightButtonType: rightButtonType,
+            onRightButtonTap: onRightButtonTap
         ))
     }
     
@@ -30,7 +33,6 @@ extension View {
         clipShape(RoundedCorner(radius: radius, corners: corners))
     }
     
-    // 키보드 숨기기 확장 함수
     func hideKeyboard() {
         UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
     }

--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Manager/TokenInterceptor.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Manager/TokenInterceptor.swift
@@ -55,7 +55,7 @@ final class TokenInterceptor: RequestInterceptor {
             instance: BaseResponse<PatchReissueResponse>.self
         ) { response in
             if response.success {
-                print("토큰 재발급 완료 -> 기존 요청 재시도")
+                print("✅ 토큰 재발급 완료 -> 기존 요청 재시도")
                 if let tokenData = response.data {
                     TokenManager.shared.updateToken(tokenData.accessToken, tokenData.refreshToken)
                 }
@@ -63,7 +63,7 @@ final class TokenInterceptor: RequestInterceptor {
             } else {
                 print("🚨 토큰 갱신 실패")
                 TokenManager.shared.clearAll()
-                // 내비게이션 매니저 필요한디... 루트뷰 로그인화면으로 바꿔야 함... 어떻게 가져올까 고민해봐야 할듯 ㅠ
+                NavigationManager.shared.rootView = .login
                 completion(.doNotRetryWithError(error))
             }
         }

--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Navigation/NavigationManager.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Navigation/NavigationManager.swift
@@ -9,14 +9,10 @@ import SwiftUI
 
 /// `NavigationPath` 관리하는 전역 내비게이션 매니저
 final class NavigationManager: ObservableObject {
+    static let shared = NavigationManager()
+    
     @Published var groupId: Int? = nil
     @Published var groupType: String? = nil
-    
-    enum RootView {
-        case login
-        case tabBar
-    }
-    
     @Published var path = NavigationPath()
     @Published var presentedDestination: PresentableDestination? = nil
     @Published var rootView: RootView = .login {
@@ -26,6 +22,11 @@ final class NavigationManager: ObservableObject {
         }
     }
     @Published var selectedTab: TabBarState = .home
+    
+    enum RootView {
+        case login
+        case tabBar
+    }
     
     func push<T: Hashable>(view: T) {
         path.append(view)

--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Resource/Assets.xcassets/Icon/ic_report_48.imageset/Contents.json
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Resource/Assets.xcassets/Icon/ic_report_48.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "ic_report_48.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Resource/Assets.xcassets/Icon/ic_report_48.imageset/ic_report_48.svg
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Resource/Assets.xcassets/Icon/ic_report_48.imageset/ic_report_48.svg
@@ -1,0 +1,7 @@
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="16" y="30" width="16" height="3" stroke="#C2C2C2" stroke-width="1.5"/>
+<path d="M18 26C18 22.6863 20.6863 20 24 20V20C27.3137 20 30 22.6863 30 26V30H18V26Z" stroke="#C2C2C2" stroke-width="1.5"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M23.5 18L23.5 15L25 15L25 18L23.5 18Z" fill="#C2C2C2"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M20.0459 19.3477L18.8222 16.6126L20.1914 16L21.4151 18.7351L20.0459 19.3477Z" fill="#C2C2C2"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M28.144 19.351L29.3692 16.6126L28 16L26.7748 18.7384L28.144 19.351Z" fill="#C2C2C2"/>
+</svg>

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/View/AddMeetingView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/View/AddMeetingView.swift
@@ -15,20 +15,6 @@ struct AddMeetingView: View {
     var body: some View {
         ZStack {
             VStack(alignment: .leading, spacing: 0) {
-                HStack {
-                    Button(action: {
-                        if viewModel.currentIndex == 0 {
-                            navigationManager.pop()
-                        } else {
-                            viewModel.currentIndex -= 1
-                        }
-                    }) {
-                        Image(.icArrowLeft48)
-                            .foregroundColor(.gray04)
-                            .frame(width: 48, height: 48)
-                    }
-                }
-                
                 ProgressBar(currentIndex: viewModel.currentIndex)
                     .padding(.bottom, 40)
                 
@@ -74,6 +60,12 @@ struct AddMeetingView: View {
                 .padding(.vertical, 20)
                 .padding(.horizontal, 16)
             }
+            .customNavigationBar(
+                showBackButton: true,
+                onBackButtonTap: {
+                    goBackToPreviousStep()
+                }
+            )
             
             let image = viewModel.isSuccessGetData ? "img_success" : "img_fail"
             
@@ -97,6 +89,17 @@ struct AddMeetingView: View {
         .ignoresSafeArea(.keyboard)
         .onAppear {
             viewModel.getTimeTable()
+        }
+    }
+}
+
+extension AddMeetingView {
+    
+    private func goBackToPreviousStep() {
+        if viewModel.currentIndex == 0 {
+            navigationManager.pop()
+        } else {
+            viewModel.currentIndex -= 1
         }
     }
 }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/View/CategorySelect.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/View/CategorySelect.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct CategorySelect: View {
-    @EnvironmentObject var navigationManager: NavigationManager
     @ObservedObject var viewModel: AddMeetingViewModel
     
     private let columns = [

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/View/IntroduceInput.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/View/IntroduceInput.swift
@@ -10,7 +10,6 @@ import SwiftUI
 import Combine
 
 struct IntroduceInput: View {
-    @EnvironmentObject var navigationManager: NavigationManager
     @ObservedObject var viewModel: AddMeetingViewModel
         
     @State var showError: Bool = false

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/View/LocationInput.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/View/LocationInput.swift
@@ -10,7 +10,6 @@ import SwiftUI
 import Combine
 
 struct LocationInput: View {
-    @EnvironmentObject var navigationManager: NavigationManager
     @ObservedObject var viewModel: AddMeetingViewModel
         
     @State private var location: String = ""

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/View/WeekDaySelect.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/View/WeekDaySelect.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct WeekDaySelect: View {
-    @EnvironmentObject var navigationManager: NavigationManager
     @ObservedObject var viewModel: AddMeetingViewModel
         
     var body: some View {

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Filling/View/FillingView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Filling/View/FillingView.swift
@@ -37,7 +37,7 @@ struct FillingView: View {
             }
             
         }
-        .customNavigationBar(title: "채우기", showXButton: false)
+        .customNavigationBar(title: "채우기")
         .onAppear {
             viewModel.getFillling()
         }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Filling/View/FillingView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Filling/View/FillingView.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 struct FillingView: View {
-    @StateObject private var viewModel = FillingViewModel()
     @EnvironmentObject var navigationManager: NavigationManager
+    @StateObject private var viewModel = FillingViewModel()
     
     var body: some View {
         ZStack(alignment: .bottomTrailing) {

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Home/View/HomeView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Home/View/HomeView.swift
@@ -176,11 +176,6 @@ struct HomeView: View {
                 .foregroundStyle(.gray03)
             
             Spacer()
-            
-            Image(.icNotification20)
-                .renderingMode(.original)
-                .scaledToFit()
-                .frame(width: 20, height: 20)
         }
     }
     

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Login/View/AgreementView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Login/View/AgreementView.swift
@@ -52,6 +52,7 @@ struct AgreementView: View {
                     isActivated: isAllChecked,
                     onTap: { navigateToOnboardingView() }
                 )
+                .padding(.bottom, 20)
             }
             .padding(.horizontal, 16)
             .padding(.top, 38)

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Login/View/AgreementView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Login/View/AgreementView.swift
@@ -56,7 +56,7 @@ struct AgreementView: View {
             .padding(.horizontal, 16)
             .padding(.top, 38)
         }
-        .customNavigationBar(title: "약관 동의", showBackButton: true)
+        .customNavigationBar(viewName: "약관 동의", showBackButton: true)
         .onChange(of: [isTermsSelected, isPrivacySelected]) {
             updateIsChecked()
         }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Login/View/LoginView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Login/View/LoginView.swift
@@ -41,7 +41,6 @@ struct LoginView: View {
                 navigationManager.push(view: LoginDestination.agree)
             case .existingUser:
                 navigationManager.rootView = .tabBar
-                navigationManager.selectedTab = .home
             case .none:
                 break
             }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingDetail/View/MeetingDetailView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingDetail/View/MeetingDetailView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct MeetingDetailView: View {
     @EnvironmentObject var navigationManager: NavigationManager
+    @Environment(\.openURL) private var openURL
     @StateObject var viewModel = MeetingDetailViewModel()
     let groupId: Int
     let groupType: String
@@ -25,7 +26,15 @@ struct MeetingDetailView: View {
                 
                 MeetingDetailSegmentControlBar(viewModel: viewModel)
             }
-            .customNavigationBar(showBackButton: true)
+            .customNavigationBar(
+                viewName: "채우기",
+                showBackButton: true,
+                rightButtonType: .report
+            ) {
+                if let url = URL(string: "https://docs.google.com/forms/d/e/1FAIpQLSeKiXqJWDIPdPJ-dm_amjsSc4jFvzr9PE8ysMykVZih8WZDJw/viewform?usp=sharing") {
+                    openURL(url)
+                }
+            }
             
             .onAppear {
                 viewModel.fetchAllData(groupId: groupId, groupType: groupType)

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingDetail/View/MeetingDetailView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingDetail/View/MeetingDetailView.swift
@@ -85,7 +85,6 @@ struct MeetingDetailView: View {
                         viewModel.showDeleteAlert = false
                         
                         viewModel.isSuccessGetData ? navigationManager.pop() : nil
-                        print("pop")
                     }
                 )
             }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingRoom/View/MeetingRoomView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingRoom/View/MeetingRoomView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 import Combine
 
 struct MeetingRoomView: View {
-    @EnvironmentObject var navigationManager: NavigationManager
     @StateObject var viewModel: MeetingRoomViewModel
     let groupId: Int
     let groupType: String

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MyPage/View/MyPageView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MyPage/View/MyPageView.swift
@@ -14,20 +14,14 @@ struct MyPageView: View {
     var body: some View {
         ZStack {
             VStack(spacing: 0) {
-                //임시 버튼
-                Button(action: {
-                    navigationManager.push(view: MyPageDestination.myPageSetting)
-                }) {
-                    Image(.icSetting48)
-                        .resizable()
-                        .frame(width: 48, height: 48)
-                }
-                
                 MyProfile(profile: viewModel.myProfile)
                 Rectangle()
                     .fill(.gray01)
                     .frame(height: 8)
                 MyPageSegmentControlBar(viewModel: viewModel)
+            }
+            .customNavigationBar(title: "마이페이지", rightButtonType: .setting) {
+                navigationManager.push(view: MyPageDestination.myPageSetting)
             }
             
             if viewModel.showAlert {
@@ -37,7 +31,6 @@ struct MyPageView: View {
                 })
             }
         }
-        .customNavigationBar(title: "마이페이지")
         .onAppear {
             viewModel.getMyProfile()
         }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MyPage/View/MyPageView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MyPage/View/MyPageView.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 struct MyPageView: View {
-    @StateObject var viewModel = MyPageViewModel()
     @EnvironmentObject var navigationManager: NavigationManager
+    @StateObject var viewModel = MyPageViewModel()
     
     var body: some View {
         ZStack {

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MyPageSetting/View/MyPageSettingView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MyPageSetting/View/MyPageSettingView.swift
@@ -42,6 +42,7 @@ struct MyPageSettingView: View {
                 )
             }
         }
+        .customNavigationBar(viewName: "설정", showBackButton: true)
         .onChange(of: viewModel.isSignedOut) {
             if viewModel.isSignedOut {
                 navigationManager.rootView = .login

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Onboarding/OnboardingView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Onboarding/OnboardingView.swift
@@ -67,7 +67,7 @@ struct OnboardingView: View {
                     }
                 )
                 .padding(.horizontal, 16)
-                .frame(height: 94)
+                .padding(.bottom, 20)
             }
         }
     }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/View/SchoolMajorSearchView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/View/SchoolMajorSearchView.swift
@@ -14,32 +14,35 @@ struct SchoolMajorSearchView: View {
     
     var body: some View {
         ZStack {
-            VStack(spacing: 0) {
-                searchTextField()
-                
-                if !viewModel.searchWord.isEmpty {
-                    if viewModel.searchResultList.isEmpty {
-                        emptyView()
+            GeometryReader { _ in
+                VStack(spacing: 0) {
+                    searchTextField()
+                    
+                    if !viewModel.searchWord.isEmpty {
+                        if viewModel.searchResultList.isEmpty {
+                            emptyView()
+                        } else {
+                            searchResultListView()
+                        }
+                        
+                        if state == .major {
+                            MajorDirectRegistrationButton(majorName: viewModel.searchWord) {
+                                viewModel.majorName = viewModel.searchWord
+                                navigationManager.dismissPresented()
+                            }
+                            .padding(.horizontal, 16)
+                        }
                     } else {
-                        searchResultListView()
+                        Spacer()
                     }
                     
-                    if state == .major {
-                        MajorDirectRegistrationButton(majorName: viewModel.searchWord) {
-                            viewModel.majorName = viewModel.searchWord
-                            navigationManager.dismissPresented()
-                        }
-                        .padding(.horizontal, 16)
-                    }
-                } else {
-                    Spacer()
+                    applyButton()
                 }
-                
-                applyButton()
+                .customNavigationBar(title: "검색하기", rightButtonType: .x) {
+                    navigationManager.dismissPresented()
+                }
             }
-            .customNavigationBar(title: "검색하기", rightButtonType: .x) {
-                navigationManager.dismissPresented()
-            }
+            .ignoresSafeArea(.keyboard)
             
             if viewModel.showAlert {
                 CustomedAlert(
@@ -53,7 +56,6 @@ struct SchoolMajorSearchView: View {
                 )
             }
         }
-        
     }
     
     private func searchTextField() -> some View {

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/View/SchoolMajorSearchView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/View/SchoolMajorSearchView.swift
@@ -37,7 +37,9 @@ struct SchoolMajorSearchView: View {
                 
                 applyButton()
             }
-            .customNavigationBar(title: "검색하기", showXButton: true)
+            .customNavigationBar(title: "검색하기", rightButtonType: .x) {
+                navigationManager.dismissPresented()
+            }
             
             if viewModel.showAlert {
                 CustomedAlert(

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/View/SignupView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/View/SignupView.swift
@@ -15,48 +15,51 @@ struct SignupView: View {
     
     var body: some View {
         ZStack {
-            VStack(spacing: 0) {
-                if currentStep != .signupCompletion {
-                    ProgressBar(currentIndex: currentStep.rawValue)
-                }
-                
-                /// currentStepIndex에 따라 변경되는 View
-                currentStep.view(
-                    viewModel: viewModel,
-                    navigationManager: navigationManager,
-                    showYearPicker: $showYearPicker
-                )
-                
-                Spacer()
-                
-                BasicButton(
-                    text: currentStep == .signupCompletion
-                    ? "공백 채우러 가기" : (currentStep == .classTimeTableInput ? "가입 완료" : "다음"),
-                    isActivated: viewModel.isNextButtonEnabled(currentStep)
-                ) {
-                    switch currentStep {
-                    case .nicknameSexInput:
-                        validateNickname()
-                    case .classTimeTableInput:
-                        signup()
-                    case .signupCompletion:
-                        goToTabBarView()
-                    default:
-                        goToNextStep()
+            GeometryReader { _ in
+                VStack(spacing: 0) {
+                    if currentStep != .signupCompletion {
+                        ProgressBar(currentIndex: currentStep.rawValue)
                     }
+                    
+                    /// currentStepIndex에 따라 변경되는 View
+                    currentStep.view(
+                        viewModel: viewModel,
+                        navigationManager: navigationManager,
+                        showYearPicker: $showYearPicker
+                    )
+                    
+                    Spacer()
+                    
+                    BasicButton(
+                        text: currentStep == .signupCompletion
+                        ? "공백 채우러 가기" : (currentStep == .classTimeTableInput ? "가입 완료" : "다음"),
+                        isActivated: viewModel.isNextButtonEnabled(currentStep)
+                    ) {
+                        switch currentStep {
+                        case .nicknameSexInput:
+                            validateNickname()
+                        case .classTimeTableInput:
+                            signup()
+                        case .signupCompletion:
+                            goToTabBarView()
+                        default:
+                            goToNextStep()
+                        }
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 20)
                 }
-                .padding(.horizontal, 16)
-                .padding(.bottom, 20)
-            }
-            .onTapGesture {
-                hideKeyboard()
-            }
-            .customNavigationBar(
-                showBackButton: currentStep != .signupCompletion,
-                onBackButtonTap: {
-                    goBackToPreviousStep()
+                .onTapGesture {
+                    hideKeyboard()
                 }
-            )
+                .customNavigationBar(
+                    showBackButton: currentStep != .signupCompletion,
+                    onBackButtonTap: {
+                        goBackToPreviousStep()
+                    }
+                )
+            }
+            .ignoresSafeArea(.keyboard)
             
             if showYearPicker {
                 ZStack {
@@ -90,7 +93,6 @@ struct SignupView: View {
                 )
             }
         }
-        .ignoresSafeArea(.keyboard)
     }
 }
 

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/View/SignupView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/View/SignupView.swift
@@ -90,6 +90,7 @@ struct SignupView: View {
                 )
             }
         }
+        .ignoresSafeArea(.keyboard)
     }
 }
 

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/View/SignupView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/View/SignupView.swift
@@ -48,12 +48,11 @@ struct SignupView: View {
                 .padding(.horizontal, 16)
                 .padding(.bottom, 20)
             }
-            
             .onTapGesture {
                 hideKeyboard()
             }
             .customNavigationBar(
-                showBackButton: !(currentStep == .signupCompletion),
+                showBackButton: currentStep != .signupCompletion,
                 onBackButtonTap: {
                     goBackToPreviousStep()
                 }


### PR DESCRIPTION
## 🧩 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 내비게이션 바 [UI]
  - 마이페이지 설정 버튼 연결, 기존 임시 버튼 삭제
  - 모임 모집 뷰에도 내비게이션 바 적용 (원래는 따로 만들어져 있었음)
  - 모임 상세 뷰 신고 버튼 연결
- 내비게이션 바 [로직]
  - 내비바 오른쪽 버튼들... 하나하나 변수로 안 만들고 enum으로 리팩토링
- 내비게이션 매니저 [로직]
  - 싱글톤 패턴으로 변경!! ❤️‍🩹 이유: 토큰 인터셉터와 같은 외부 객체에서도 루트뷰 바꿀 수 있으려면... 내비게이션 매니절에 접근 필요..
  - 근데 외부 객체에서는 싱글톤 객체 쓰고, 뷰에서는 `@EnvironmentObject` 의존성 주입 그대로 사용!! (이유: 뷰 안정성 보장됨..)
 - 토큰 인터셉터: 토큰 재발급 실패 시 로그인 화면으로 루트뷰 변경

## 🪁 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
### ☕️ 싱글톤 패턴과 `@EnvironmentObject`주입의 합작 (main 함수)
<img width="1090" alt="image" src="https://github.com/user-attachments/assets/4f99b0df-a2ea-4bba-8a22-c2b99da6281d" />

- `@StateObject`로 내비게이션 매니저 생성했던 코드 지우고.. 
- `NavigationManager.shared` 싱글톤 객체로 최상위뷰(RootViewSwitcher)에 EnvironmentObject 주입 해줌
- 끝.


## 📱 스크린샷
<!-- 작업 내용, 스크린 샷(GIF/MP4) 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 마이페이지<br>내비게이션 바 | <img src = "https://github.com/user-attachments/assets/6d977cc9-18f1-4c9c-9d1e-a9fbcd8142f6" width ="300">|


### 🔗 Issue 
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #12
