### PR TITLE
[Fix] #35 - 자체 QA 사항 반영

### DIFF
--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Component/Bar/ApplyBar.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Component/Bar/ApplyBar.swift
@@ -10,19 +10,24 @@ import SwiftUI
 struct ApplyBar: View {
     @ObservedObject var viewModel: MeetingDetailViewModel
     
-    
     var body: some View {
         HStack(spacing: 16) {
-            Text("\(viewModel.meetingDetailData?.currentPeopleCount ?? 0) / \(viewModel.meetingDetailData?.maxPeopleCount ?? 0) 명")
-                .pretendardFont(.title2_sb_18)
-                .padding(16)
-                .foregroundStyle(viewModel.isActivated ? .gray01 : .grayWhite)
-                .background(
-                    RoundedRectangle(cornerRadius: 6)
-                        .fill(viewModel.isActivated ? .gray09 : .gray04)
+            if let data = viewModel.meetingDetailData {
+                Text("\(data.currentPeopleCount) / \(data.maxPeopleCount) 명")
+                    .pretendardFont(.title2_sb_18)
+                    .padding(16)
+                    .foregroundStyle(viewModel.isActivated(for: data) ? .gray01 : .grayWhite)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(viewModel.isActivated(for: data) ? .gray09 : .gray04)
+                    )
+                
+                BasicButton(
+                    text: viewModel.buttonText(for: data),
+                    isActivated: viewModel.isActivated(for: data),
+                    onTap: viewModel.buttonAction(for: data)
                 )
-            
-            BasicButton(text: viewModel.buttonText, isActivated: viewModel.isActivated, onTap: viewModel.buttonAction)
+            }
         }
         .padding(.vertical, 20)
         .padding(.horizontal, 16)

--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Component/Bar/Common/CustomNavigationBar.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Component/Bar/Common/CustomNavigationBar.swift
@@ -56,7 +56,7 @@ struct CustomNavigationBarModifier: ViewModifier {
                         }
                     }
                     .frame(height: 48)
-                    .background(.clear)
+                    .background(.white)
                 }
                 content
             }

--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Component/Box/OwnerProfileBox.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Component/Box/OwnerProfileBox.swift
@@ -7,56 +7,58 @@
 
 import SwiftUI
 
-//TODO: Model로 분리
-
 struct OwnerProfileBox: View {
     @ObservedObject var viewModel: MeetingDetailViewModel
     
     var body: some View {
-        HStack(spacing: 12) {
-            if let image = ProfileDefaultImageMap.init(rawValue: (viewModel.ownerInfoData?.profileImg ?? 0))?.image {
-                Image(image)
-                    .resizable()
-                    .padding(8)
-                    .background(.grayWhite)
-                    .frame(width: 80, height: 80)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 2)
-                            .stroke(.gray02, lineWidth: 1)
-                    )
-            }
-            VStack(alignment: .leading, spacing: 6) {
-                HStack(spacing: 4) {
-                    Text(viewModel.ownerInfoData?.nickname ?? "")
-                        .pretendardFont(.body1_b_16)
-                        .foregroundStyle(.grayBlack)
-                    
-                    Image(SexState(viewModel.ownerInfoData?.sex ?? "") == .MAN ? .icMale20 : .icFemale20)
+        if let ownerInfoData = viewModel.ownerInfoData {
+            HStack(spacing: 12) {
+                if let image = ProfileDefaultImageMap.init(rawValue: (ownerInfoData.profileImg))?.image {
+                    Image(image)
                         .resizable()
-                        .frame(width: 20, height: 20)
-                        .foregroundStyle(.gray06)
-                    Spacer()
+                        .padding(8)
+                        .background(.grayWhite)
+                        .frame(width: 80, height: 80)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 2)
+                                .stroke(.gray02, lineWidth: 1)
+                        )
                 }
-                
-                MajorChip(major: viewModel.ownerInfoData?.schoolMajor ?? "", targetObject: .ownerProfile)
-                
-                HStack(spacing: 6) {
-                    ProfileDetailChip(detailCategory: "학번")
-                    Text("\((viewModel.ownerInfoData?.enterYear ?? 0 )%100)학번")
-                        .foregroundStyle(.gray08)
-                        .pretendardFont(.caption2_m_12)
-                        .padding(.trailing, 6)
-                    ProfileDetailChip(detailCategory: "MBTI")
-                    Text(viewModel.ownerInfoData?.mbti ?? "")
-                        .foregroundStyle(.gray08)
-                        .pretendardFont(.caption2_m_12)
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 4) {
+                        Text(ownerInfoData.nickname)
+                            .pretendardFont(.body1_b_16)
+                            .foregroundStyle(.grayBlack)
+                        
+                        Image(SexState(ownerInfoData.sex) == .MAN ? .icMale20 : .icFemale20)
+                            .resizable()
+                            .frame(width: 20, height: 20)
+                            .foregroundStyle(.gray06)
+                        Spacer()
+                    }
+                    
+                    MajorChip(major: ownerInfoData.schoolMajor, targetObject: .ownerProfile)
+                    
+                    HStack(spacing: 6) {
+                        ProfileDetailChip(detailCategory: "학번")
+                        Text("\((ownerInfoData.enterYear)%100)학번")
+                            .foregroundStyle(.gray08)
+                            .pretendardFont(.caption2_m_12)
+                            .padding(.trailing, 6)
+                        ProfileDetailChip(detailCategory: "MBTI")
+                        Text(ownerInfoData.mbti)
+                            .foregroundStyle(.gray08)
+                            .pretendardFont(.caption2_m_12)
+                    }
                 }
+                .frame(maxWidth: .infinity)
             }
+            .padding(10)
             .frame(maxWidth: .infinity)
+            .background(
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(.gray01)
+            )
         }
-        .padding(10)
-        .frame(maxWidth: .infinity)
-        .background(RoundedRectangle(cornerRadius: 4)
-            .fill(.gray01))
     }
 }

--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Component/Button/CategoryImageButton.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Component/Button/CategoryImageButton.swift
@@ -17,23 +17,24 @@ struct CategoryImageButton: View {
             onTap?()
         }) {
             VStack(spacing: 10) {
-                if let image = category.categoryImage { image
+                if let image = category.categoryImage {
+                    let size = 78/812 * UIScreen.main.bounds.height
+                    image
                         .resizable()
                         .scaledToFit()
-                        .frame(width: 78, height: 78)
+                        .frame(width: size, height: size)
                 }
                 
                 Text(category.categoryName)
                     .font(.pretendard(.body1_m_16))
                     .foregroundColor(.gray08)
             }
-            .frame(maxWidth: .infinity, minHeight: 120)
+            .buttonStyle(PlainButtonStyle())
+            .frame(maxWidth: .infinity)
             .padding(.vertical, 15)
             .background(isSelected ? .subOrange : .gray01)
             .clipShape(RoundedRectangle(cornerRadius: 5))
         }
-        .buttonStyle(PlainButtonStyle())
-        .frame(maxWidth: .infinity, minHeight: 120)
     }
 }
 

--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Component/Chip/MeetingChip.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Component/Chip/MeetingChip.swift
@@ -12,10 +12,9 @@ struct MeetingChip: View {
     
     var body: some View {
         Text(state.titleText)
-            .font(.pretendard(.caption2_r_12))
+            .pretendardFont(.caption2_r_12)
             .foregroundColor(state.textColor)
             .padding(.horizontal, 4)
-            .padding(.vertical, 1)
             .background(state.backgroundColor)
             .cornerRadius(2)
     }

--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Component/List/CommentCell.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Component/List/CommentCell.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct CommentCell: View {
     let comment: Comment
+    var meetingDetailViewModel: MeetingDetailViewModel?
+    var meetingRoomViewModel: MeetingRoomViewModel?
     
     var body: some View {
         ZStack(alignment: .bottom) {
@@ -18,7 +20,11 @@ struct CommentCell: View {
                         .pretendardFont(.body1_sb_16)
                     comment.isGroupHost ? OwnerChip() : nil
                     Spacer()
-                    comment.isWriter ? DeleteButton() : nil
+                    if comment.isWriter {
+                        DeleteButton {
+                            deleteComment(commentId: comment.commentId)
+                        }
+                    }
                 }
                 .foregroundColor(.grayBlack)
                 .padding(.bottom, 8)
@@ -41,13 +47,29 @@ struct CommentCell: View {
     func divider() -> some View {
         Color.gray02.frame(height: 1)
     }
+    
+    private func deleteComment(commentId: Int) {
+        if let viewModel = meetingDetailViewModel {
+            viewModel.deleteComment(
+                groupId: viewModel.meeting.groupId,
+                groupType: viewModel.meeting.groupType,
+                commentId: commentId
+            )
+        } else if let viewModel = meetingRoomViewModel {
+            viewModel.deleteComment(
+                groupId: viewModel.meetingDetailData?.groupId ?? 0,
+                groupType: viewModel.meetingDetailData?.groupType ?? "",
+                commentId: commentId
+            )
+        }
+    }
 }
 
 struct DeleteButton: View {
+    let action: () -> Void
+    
     var body: some View {
-        Button (action: {
-            print("DeleteButtonTapped")
-        }) {
+        Button(action: action) {
             Image(.icCommentX20)
                 .resizable()
                 .frame(width: 20, height: 20)

--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Component/List/CommentCell.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Component/List/CommentCell.swift
@@ -16,7 +16,7 @@ struct CommentCell: View {
         ZStack(alignment: .bottom) {
             VStack(alignment: .leading, spacing: 0) {
                 HStack(alignment: .center, spacing: 6) {
-                    Text(comment.nickname)
+                    Text(comment.nickname ?? "알 수 없음")
                         .pretendardFont(.body1_sb_16)
                     comment.isGroupHost ? OwnerChip() : nil
                     Spacer()

--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Component/List/CommentCell.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Component/List/CommentCell.swift
@@ -49,10 +49,11 @@ struct CommentCell: View {
     }
     
     private func deleteComment(commentId: Int) {
-        if let viewModel = meetingDetailViewModel {
+        if let viewModel = meetingDetailViewModel,
+           let data = viewModel.meetingDetailData {
             viewModel.deleteComment(
-                groupId: viewModel.meeting.groupId,
-                groupType: viewModel.meeting.groupType,
+                groupId: data.groupId,
+                groupType: data.groupType,
                 commentId: commentId
             )
         } else if let viewModel = meetingRoomViewModel {

--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Component/List/CommentList.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Component/List/CommentList.swift
@@ -28,7 +28,11 @@ struct CommentList: View {
                             .frame(minHeight: UIScreen.main.bounds.height * height, alignment: .bottom) // 앱잼을 위해 막 짠 코드..
                     } else {
                         ForEach (comments.indices, id: \.self) { index in
-                            CommentCell(comment: comments[index])
+                            CommentCell(
+                                comment: comments[index],
+                                meetingDetailViewModel: meetingDetailViewModel,
+                                meetingRoomViewModel: meetingRoomViewModel
+                            )
                         }
                     }
                 }

--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Component/List/MeetingInfoBase.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Component/List/MeetingInfoBase.swift
@@ -13,23 +13,19 @@ struct MeetingInfoBase: View {
     
     var body: some View {
         HStack(spacing: 12) {
-            Group {
-                if let category = CategoryState(meeting.category) {
-                    Image(category.coverImage[meeting.coverImg])
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                        .frame(width: 102, height: 102)
-                        .cornerRadius(2)
-                        .clipped()
-                }
-                else {
-                    Image(.sample)
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                        .frame(width: 102, height: 102)
-                        .cornerRadius(2)
-                        .clipped()
-                }
+            if let category = CategoryState(meeting.category) {
+                Image(category.coverImage[meeting.coverImg])
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: 102, height: 102)
+                    .cornerRadius(2)
+                    .clipped()
+            }
+            else {
+                Rectangle()
+                    .fill(.gray01)
+                    .frame(width: 102, height: 102)
+                    .cornerRadius(2)
             }
             
             VStack(alignment: .leading, spacing: 6) {
@@ -79,4 +75,3 @@ struct MeetingInfoBase: View {
         }
     }
 }
-

--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Component/TextField/CustomTextEditor.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Component/TextField/CustomTextEditor.swift
@@ -28,8 +28,8 @@ struct CustomTextEditor: View {
                 if text.isEmpty {
                     Text(
                         isSignupView
-                        ? "간단한 소개글을 20자 이상 작성해보세요.\nex) 안녕하세요! 이번에 복학한 학생입니다. 함께 좋은 모임 만들어봐요~!"
-                        : "간단한 소개글을 20자 이상 작성해보세요.\nex) 화석된 사람들끼리 소소한 점심 모임 어때요?"
+                        ? "간단한 소개글을 작성해보세요.\nex) 안녕하세요! 이번에 복학한 학생입니다. 함께 좋은 모임 만들어봐요~!"
+                        : "간단한 소개글을 작성해보세요.\nex) 화석된 사람들끼리 소소한 점심 모임 어때요?"
                     )
                     .foregroundColor(.gray04)
                     .padding(EdgeInsets(top: 14, leading: 16, bottom: 14, trailing: 16))

--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Enum/MeetingChipState.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Enum/MeetingChipState.swift
@@ -62,7 +62,7 @@ extension MeetingChipState {
         case .category(let categoryState):
             return categoryState.categoryName
         case .weekly(let isWeekly):
-            return isWeekly == .WEEKLY ? "매주 보기" : "한번 보기"
+            return isWeekly == .WEEKLY ? CycleState.weekly.titleText : CycleState.once.titleText
         }
     }
 }

--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Extension/Date+.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Extension/Date+.swift
@@ -44,33 +44,24 @@ extension Date {
     }
     
     // 날짜와 시간을 포맷팅하는 함수
-    static func formattedDateAndTime(weekDay: WeekDay?, weekDate: String?, time: Double) -> String { // endTime도 필요
-        let formattedTime = formatTime(time)
-        
-        if let weekDay = weekDay {
-            return "매주 \(weekDay.koreanName) \(formattedTime)"
-        } else if let weekDate = weekDate {
-            let formattedDate = formatDate(weekDate)
-            return "\(formattedDate) \(formattedTime)"
-        }
-        
-        return "시간 정보 없음"
-    }
-    
-    // 날짜와 시간을 포맷팅하는 함수
-    static func formattedDateAndStartEndTime(weekDay: WeekDay?, weekDate: String?, startTime: Double, endTime: Double) -> String {
+    static func formattedDateAndStartEndTime(
+        weekDay: WeekDay?,
+        weekDate: String?,
+        startTime: Double,
+        endTime: Double
+    ) -> String {
         let formattedStartTime = formatTime(startTime)
         let formattedEndTime = formatTime(endTime)
         
         if let weekDate = weekDate {
             let formattedDate = formatDate(weekDate)
-            return "\(formattedDate) \(weekDay?.koreanName ?? "ㅗ") \(formattedStartTime) - \(formattedEndTime)"
+            return "\(formattedDate) \(weekDay?.koreanName ?? "") \(formattedStartTime) - \(formattedEndTime)"
         }
         
         if let weekDay = weekDay {
             return "매주 \(weekDay.koreanName) \(formattedStartTime) - \(formattedEndTime)"
         }
-        return "시간 정보 없음"
+        return ""
     }
 
     
@@ -110,5 +101,4 @@ extension Date {
         let year = Calendar.current.component(.year, from: Date())
         return asString ? "\(year)" : year
     }
-    
 }

--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Util/KeyboardObserver.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Util/KeyboardObserver.swift
@@ -1,0 +1,30 @@
+//
+//  KeyboardObserver.swift
+//  Gongbaek_iOS
+//
+//  Created by 김나연 on 5/9/25.
+//
+
+import SwiftUI
+import Combine
+
+class KeyboardObserver: ObservableObject {
+    @Published var keyboardHeight: CGFloat = 0
+
+    private var cancellableSet: Set<AnyCancellable> = []
+
+    init() {
+        NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)
+            .compactMap { ($0.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect)?.height }
+            .sink { [weak self] height in
+                self?.keyboardHeight = height
+            }
+            .store(in: &cancellableSet)
+
+        NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)
+            .sink { [weak self] _ in
+                self?.keyboardHeight = 0
+            }
+            .store(in: &cancellableSet)
+    }
+}

--- a/Gongbaek_iOS/Gongbaek_iOS/Network/Service/DTO/Comment/DeleteCommentRequestDTO.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Network/Service/DTO/Comment/DeleteCommentRequestDTO.swift
@@ -1,0 +1,12 @@
+//
+//  DeleteCommentRequestDTO.swift
+//  Gongbaek_iOS
+//
+//  Created by 김나연 on 5/9/25.
+//
+
+import Foundation
+
+struct DeleteCommentRequestDTO: Codable {
+    let commentId: Int
+}

--- a/Gongbaek_iOS/Gongbaek_iOS/Network/Service/DTO/Comment/GetCommentsResponseDTO.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Network/Service/DTO/Comment/GetCommentsResponseDTO.swift
@@ -19,7 +19,7 @@ struct Comment: Codable {
     var commentId: Int
     var isWriter: Bool
     var isGroupHost: Bool
-    var nickname: String
+    var nickname: String?
     var body: String
     var createdAt: String
 }

--- a/Gongbaek_iOS/Gongbaek_iOS/Network/Service/TargetType/CommentTargetType.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Network/Service/TargetType/CommentTargetType.swift
@@ -10,6 +10,7 @@ import Moya
 enum CommentTargetType {
     case getComments(isPublic: Bool, groupId: Int, groupType: String)
     case postComment(data: PostCommentRequestBodyDTO)
+    case deleteComment(data: DeleteCommentRequestDTO)
 }
 
 extension CommentTargetType: BaseTargetType {
@@ -18,6 +19,8 @@ extension CommentTargetType: BaseTargetType {
         case .getComments:
             return APIConstants.accessTokenHeader
         case .postComment:
+            return APIConstants.accessTokenHeader
+        case .deleteComment:
             return APIConstants.accessTokenHeader
         }
     }
@@ -28,6 +31,8 @@ extension CommentTargetType: BaseTargetType {
             return "/api/v1/comments"
         case .postComment:
             return "/api/v1/comment"
+        case .deleteComment:
+            return "/api/v1/comment"
         }
     }
     
@@ -37,6 +42,8 @@ extension CommentTargetType: BaseTargetType {
             return .get
         case .postComment:
             return .post
+        case .deleteComment:
+            return .delete
         }
     }
     
@@ -52,6 +59,8 @@ extension CommentTargetType: BaseTargetType {
                 encoding: URLEncoding.queryString
             )
         case .postComment(let data):
+            return .requestJSONEncodable(data)
+        case .deleteComment(let data):
             return .requestJSONEncodable(data)
         }
     }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/View/AddMeetingView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/View/AddMeetingView.swift
@@ -11,7 +11,7 @@ struct AddMeetingView: View {
     @EnvironmentObject var navigationManager: NavigationManager
     @StateObject var viewModel: AddMeetingViewModel
     @StateObject private var keyboard = KeyboardObserver()
-    @State private var showAlert: Bool = false
+    @State private var alertState: Bool? = nil
     
     var body: some View {
         ZStack {
@@ -50,7 +50,6 @@ struct AddMeetingView: View {
                     
                     Spacer()
                     
-                    // ✅ 버튼 동적 변경을 위한 변수 추가
                     let isLastStep = viewModel.currentIndex == viewModel.totalSteps - 1
                     
                     BasicButton(
@@ -58,8 +57,9 @@ struct AddMeetingView: View {
                         isActivated: viewModel.isNextButtonEnabled()
                     ) {
                         if isLastStep {
-                            viewModel.postMeeting()
-                            showAlert = true
+                            viewModel.postMeeting() { isSuccess in
+                                alertState = isSuccess
+                            }
                         } else {
                             viewModel.goToNextPage()
                         }
@@ -75,16 +75,14 @@ struct AddMeetingView: View {
                     }
                 )
                 
-                let image = viewModel.isSuccessGetData ? "img_success" : "img_fail"
-                
-                if showAlert {
+                if let isSuccess = alertState {
                     GongbaekAlert(
-                        alertImage: image ,
-                        titleText: viewModel.isSuccessGetData ? "모임 등록이 완료됐어요!" : "모임 등록에 실패했어요!",
+                        alertImage: isSuccess ? "img_success" : "img_fail",
+                        titleText: isSuccess ? "모임 등록이 완료됐어요!" : "모임 등록에 실패했어요!",
                         orangeButtonText: "확인",
                         onTapOrangeButton: {
-                            showAlert = false
-                            if viewModel.isSuccessGetData {
+                            alertState = nil
+                            if isSuccess {
                                 navigationManager.popToRoot()
                                 navigationManager.selectedTab = .filling
                             } else {

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/View/AddMeetingView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/View/AddMeetingView.swift
@@ -10,83 +10,92 @@ import SwiftUI
 struct AddMeetingView: View {
     @EnvironmentObject var navigationManager: NavigationManager
     @StateObject var viewModel: AddMeetingViewModel
+    @StateObject private var keyboard = KeyboardObserver()
     @State private var showAlert: Bool = false
     
     var body: some View {
         ZStack {
-            VStack(alignment: .leading, spacing: 0) {
-                ProgressBar(currentIndex: viewModel.currentIndex)
-                    .padding(.bottom, 40)
-                
-                switch viewModel.currentIndex {
-                case 0:
-                    CycleSelect(viewModel: viewModel)
-                case 1:
-                    if viewModel.selectedCycle == .once {
-                        CalendarSelect(viewModel: viewModel)
-                    } else if viewModel.selectedCycle == .weekly {
-                        WeekDaySelect(viewModel: viewModel)
+            GeometryReader { _ in
+                VStack(alignment: .leading, spacing: 0) {
+                    ProgressBar(currentIndex: viewModel.currentIndex)
+                    
+                    ScrollView {
+                        Group {
+                            switch viewModel.currentIndex {
+                            case 0:
+                                CycleSelect(viewModel: viewModel)
+                            case 1:
+                                if viewModel.selectedCycle == .once {
+                                    CalendarSelect(viewModel: viewModel)
+                                } else if viewModel.selectedCycle == .weekly {
+                                    WeekDaySelect(viewModel: viewModel)
+                                }
+                            case 2:
+                                TimeSelect(viewModel: viewModel)
+                            case 3:
+                                CategorySelect(viewModel: viewModel)
+                            case 4:
+                                CoverImageSelect(viewModel: viewModel)
+                            case 5:
+                                LocationInput(viewModel: viewModel)
+                            case 6:
+                                IntroduceInput(viewModel: viewModel)
+                            default:
+                                CheckInputInfo(viewModel: viewModel)
+                            }
+                        }
+                        .padding(.top, 40)
+                        .padding(.bottom, keyboard.keyboardHeight)
                     }
-                case 2:
-                    TimeSelect(viewModel: viewModel)
-                case 3:
-                    CategorySelect(viewModel: viewModel)
-                case 4:
-                    CoverImageSelect(viewModel: viewModel)
-                case 5:
-                    LocationInput(viewModel: viewModel)
-                case 6:
-                    IntroduceInput(viewModel: viewModel)
-                default:
-                    CheckInputInfo(viewModel: viewModel)
-                }
-                
-                Spacer()
-                
-                // ✅ 버튼 동적 변경을 위한 변수 추가
-                let isLastStep = viewModel.currentIndex == viewModel.totalSteps - 1
-                
-                BasicButton(
-                    text: isLastStep ? "등록하기" : "다음",
-                    isActivated: viewModel.isNextEnabled
-                ) {
-                    if isLastStep {
-                        viewModel.postMeeting()
-                        showAlert = true
-                    } else {
-                        viewModel.goToNextPage()
-                    }
-                }
-                .padding(.vertical, 20)
-                .padding(.horizontal, 16)
-            }
-            .customNavigationBar(
-                showBackButton: true,
-                onBackButtonTap: {
-                    goBackToPreviousStep()
-                }
-            )
-            
-            let image = viewModel.isSuccessGetData ? "img_success" : "img_fail"
-            
-            if showAlert {
-                CustomedAlert(
-                    alertImage: image ,
-                    titleText: viewModel.isSuccessGetData ? "모임 등록이 완료됐어요!" : "모임 등록에 실패했어요!",
-                    orangeButtonText: "확인",
-                    onTapOrangeButton: {
-                        showAlert = false
-                        if viewModel.isSuccessGetData {
-                            navigationManager.popToRoot()
-                            navigationManager.selectedTab = .filling
+                    
+                    Spacer()
+                    
+                    // ✅ 버튼 동적 변경을 위한 변수 추가
+                    let isLastStep = viewModel.currentIndex == viewModel.totalSteps - 1
+                    
+                    BasicButton(
+                        text: isLastStep ? "등록하기" : "다음",
+                        isActivated: viewModel.isNextEnabled
+                    ) {
+                        if isLastStep {
+                            viewModel.postMeeting()
+                            showAlert = true
                         } else {
-                            viewModel.retryCount += 1
+                            viewModel.goToNextPage()
                         }
                     }
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 20)
+                    .background(.clear)
+                }
+                .customNavigationBar(
+                    showBackButton: true,
+                    onBackButtonTap: {
+                        goBackToPreviousStep()
+                    }
                 )
+                
+                let image = viewModel.isSuccessGetData ? "img_success" : "img_fail"
+                
+                if showAlert {
+                    CustomedAlert(
+                        alertImage: image ,
+                        titleText: viewModel.isSuccessGetData ? "모임 등록이 완료됐어요!" : "모임 등록에 실패했어요!",
+                        orangeButtonText: "확인",
+                        onTapOrangeButton: {
+                            showAlert = false
+                            if viewModel.isSuccessGetData {
+                                navigationManager.popToRoot()
+                                navigationManager.selectedTab = .filling
+                            } else {
+                                viewModel.retryCount += 1
+                            }
+                        }
+                    )
+                }
             }
+            .ignoresSafeArea(.keyboard)
         }
-        .ignoresSafeArea(.keyboard)
         .onAppear {
             viewModel.getTimeTable()
         }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/View/AddMeetingView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/View/AddMeetingView.swift
@@ -55,7 +55,7 @@ struct AddMeetingView: View {
                     
                     BasicButton(
                         text: isLastStep ? "등록하기" : "다음",
-                        isActivated: viewModel.isNextEnabled
+                        isActivated: viewModel.isNextButtonEnabled()
                     ) {
                         if isLastStep {
                             viewModel.postMeeting()

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/View/CalendarSelect.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/View/CalendarSelect.swift
@@ -12,7 +12,7 @@ struct CalendarSelect: View {
         
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            TitleTextBox(title: "활동주기를 선택해주세요.", subtitle: nil)
+            TitleTextBox(title: "공백을 채울 날짜를 선택해주세요.", subtitle: nil)
                 .padding(.bottom, 68)
             
             CustomCalendar(selectedDate: $viewModel.selectedWeekDate)

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/View/CategorySelect.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/View/CategorySelect.swift
@@ -34,5 +34,3 @@ struct CategorySelect: View {
         .padding(.horizontal, 16)
     }
 }
-
-

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/View/CoverImageSelect.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/View/CoverImageSelect.swift
@@ -30,7 +30,6 @@ struct CoverImageSelect: View {
                         isSelected: viewModel.selectedCoverIndex == index,
                         onTap: {
                             viewModel.selectedCoverIndex = index
-                            print("✅ 선택된 커버 인덱스 (서버 기준): \(viewModel.selectedCoverIndex)")
                         }
                     )
                     .frame(height: 138)

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/View/CoverImageSelect.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/View/CoverImageSelect.swift
@@ -11,8 +11,8 @@ struct CoverImageSelect: View {
     @ObservedObject var viewModel: AddMeetingViewModel
     
     private let columns = [
-        GridItem(.flexible(), spacing: 12),
-        GridItem(.flexible(), spacing: 12)
+        GridItem(.flexible(), spacing: 8),
+        GridItem(.flexible(), spacing: 8)
     ]
     
     var body: some View {
@@ -23,7 +23,7 @@ struct CoverImageSelect: View {
             TitleTextBox(title: "커버 사진을 선택해주세요.", subtitle: "제공된 사진 중 하나를 선택할 수 있어요.")
                 .padding(.bottom, 28)
             
-            LazyVGrid(columns: columns, spacing: 12) {
+            LazyVGrid(columns: columns, spacing: 8) {
                 ForEach(enumeratedCoverImages, id: \.0) { index, image in
                     CoverImageButton(
                         image: image,
@@ -38,6 +38,5 @@ struct CoverImageSelect: View {
             }
         }
         .padding(.horizontal, 16)
-        
     }
 }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/View/LocationInput.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/View/LocationInput.swift
@@ -18,7 +18,7 @@ struct LocationInput: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            TitleTextBox(title: "활동주기를 선택해주세요.", subtitle: nil)
+            TitleTextBox(title: "만날 장소를 작성해주세요.", subtitle: nil)
                 .padding(.bottom, 20)
             
             CustomTextField(

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/View/TimeSelect.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/View/TimeSelect.swift
@@ -24,31 +24,29 @@ struct TimeSelect: View {
             }
             .padding(.bottom, 30)
             
-            ScrollView {
-                HStack(spacing: 12) {
-                    Text("나의 시간표")
-                        .font(.pretendard(.body1_b_16))
-                        .foregroundColor(.gray08)
-                    Spacer()
-                    Button(action: {
-                        viewModel.selectedTimeRange = (start: 0, end: 0)
-                        viewModel.selectedCells.removeAll()
-                    }) {
-                        HStack(spacing: 0) {
-                            Text("다시 선택")
-                                .font(.pretendard(.caption2_m_12))
-                                .foregroundColor(.mainOrange)
-                            Image(.icOptionReset18)
-                                .foregroundColor(.mainOrange)
-                                .frame(width: 18, height: 18)
-                        }
+            HStack(spacing: 12) {
+                Text("나의 시간표")
+                    .font(.pretendard(.body1_b_16))
+                    .foregroundColor(.gray08)
+                Spacer()
+                Button(action: {
+                    viewModel.selectedTimeRange = (start: 0, end: 0)
+                    viewModel.selectedCells.removeAll()
+                }) {
+                    HStack(spacing: 0) {
+                        Text("다시 선택")
+                            .font(.pretendard(.caption2_m_12))
+                            .foregroundColor(.mainOrange)
+                        Image(.icOptionReset18)
+                            .foregroundColor(.mainOrange)
+                            .frame(width: 18, height: 18)
                     }
                 }
-                .padding(.bottom, 10)
-                
-                AddMeetingTimeTable(viewModel: viewModel)
-                    .padding(.bottom, 8)
             }
+            .padding(.bottom, 10)
+            
+            AddMeetingTimeTable(viewModel: viewModel)
+                .padding(.bottom, 8)
             
         }
         .padding(.horizontal, 16)

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/View/WeekDaySelect.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/View/WeekDaySelect.swift
@@ -12,7 +12,7 @@ struct WeekDaySelect: View {
         
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            TitleTextBox(title: "활동주기를 선택해주세요.", subtitle: nil)
+            TitleTextBox(title: "공백을 채울 요일을 선택해주세요.", subtitle: nil)
                 .padding(.bottom, 60)
             
             VStack(spacing: 16) {

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/ViewModel/AddMeetingViewModel.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/ViewModel/AddMeetingViewModel.swift
@@ -183,8 +183,8 @@ class AddMeetingViewModel: ObservableObject {
     func getFormattedDateTime() -> String {
         guard let selectedCycle = selectedCycle else { return "날짜와 시간을 선택해주세요." }
         
-        let startHour = Int(selectedTimeRange.start)
-        let endHour = Int(selectedTimeRange.end)
+        let startTime = Date.formatTime(selectedTimeRange.start)
+        let endTime = Date.formatTime(selectedTimeRange.end)
         
         if selectedCycle == .once {
             guard let selectedDate = selectedWeekDate else { return "날짜 선택 필요" }
@@ -194,11 +194,11 @@ class AddMeetingViewModel: ObservableObject {
             dateFormatter.locale = Locale(identifier: "ko_KR")
             
             let formattedDate = dateFormatter.string(from: selectedDate)
-            return "\(formattedDate) \(startHour)시 - \(endHour)시"
+            return "\(formattedDate) \(startTime) - \(endTime)"
             
         } else if selectedCycle == .weekly {
             guard let selectedWeekDay = selectedWeekDay else { return "요일 선택 필요" }
-            return "매주 \(selectedWeekDay.rawValue) \(startHour)시 - \(endHour)시"
+            return "매주 \(selectedWeekDay.rawValue) \(startTime) - \(endTime)"
         }
         
         return "날짜와 시간을 선택해주세요."

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/ViewModel/AddMeetingViewModel.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/ViewModel/AddMeetingViewModel.swift
@@ -28,7 +28,6 @@ class AddMeetingViewModel: ObservableObject {
     @Published var maxPeopleCount: Int = 2
     @Published var title: String = ""
     @Published var introduction: String = ""
-    @Published var isSuccessGetData: Bool = true
     @Published var retryCount = 0 {
         didSet {
             if retryCount > 3 {
@@ -217,24 +216,19 @@ class AddMeetingViewModel: ObservableObject {
         }
     }
     
-    func postMeeting() {
+    func postMeeting(completion: @escaping (Bool) -> ()) {
         guard selectedCoverIndex != nil else { return }
-        
         let requestData = makeMeetingModel()
-        
         print("🛠️ 최종 weekDate 값: \(requestData.weekDate)")
         
         Providers.fillingProvider.request(target: .postMeeting(data: requestData), instance: BaseResponse<EmptyResponseDTO>.self) { response in
-            print(requestData)
-            DispatchQueue.main.async {
-                if response.success {
-                    self.isSuccessGetData = true
-                    self.retryCount = 0 // 성공 시 횟수 초기화
-                    print("✅ 모임 등록 성공!")
-                } else {
-                    self.isSuccessGetData = false
-                }
+            if response.success {
+                self.retryCount = 0
+                print("✅ 모임 등록 성공!")
+            } else {
+                print("❌ 모임 등록 실패")
             }
+            completion(response.success)
         }
     }
     

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/ViewModel/AddMeetingViewModel.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/AddMeeting/ViewModel/AddMeetingViewModel.swift
@@ -12,59 +12,23 @@ class AddMeetingViewModel: ObservableObject {
     let totalSteps: Int = 8
     
     @Published var currentIndex: Int = 0
-    
-    @Published var isNextEnabled: Bool = false
-    
-    @Published var selectedCycle: CycleState? = nil {
-        didSet { updateNextButtonState() }
-    }
-    
+    @Published var selectedCycle: CycleState? = nil
     @Published var selectedWeekDate: Date? = nil {
         didSet {
             updateSelectedWeekDay()
-            updateNextButtonState()
         }
     }
-    
-    @Published var selectedWeekDay: WeekDay? = nil {
-        didSet { updateNextButtonState() }
-    }
-    
-    @Published var selectedCategory: CategoryState? = nil {
-        didSet { updateNextButtonState() }
-    }
-    
-    @Published var selectedCoverIndex: Int? = nil {
-        didSet { updateNextButtonState() }
-    }
-    
+    @Published var selectedWeekDay: WeekDay? = nil
+    @Published var selectedCategory: CategoryState? = nil
+    @Published var selectedCoverIndex: Int? = nil
     @Published var timeTable: [TimeTableModel] = []
-    @Published var selectedCells: Set<TimeTableCellId> = [] {
-        didSet { updateNextButtonState() }
-    }
-    
-    @Published var selectedTimeRange: (start: Double, end: Double) = (0, 0) {
-        didSet {
-            updateNextButtonState()
-        }
-    }
-    
-    @Published var location: String = "" {
-        didSet { updateNextButtonState() }
-    }
-    
+    @Published var selectedCells: Set<TimeTableCellId> = []
+    @Published var selectedTimeRange: (start: Double, end: Double) = (0, 0)
+    @Published var location: String = ""
     @Published var maxPeopleCount: Int = 2
-    
-    @Published var title: String = "" {
-        didSet { updateNextButtonState() }
-    }
-    
-    @Published var introduction: String = "" {
-        didSet { updateNextButtonState() }
-    }
-    
+    @Published var title: String = ""
+    @Published var introduction: String = ""
     @Published var isSuccessGetData: Bool = true
-    
     @Published var retryCount = 0 {
         didSet {
             if retryCount > 3 {
@@ -83,10 +47,9 @@ class AddMeetingViewModel: ObservableObject {
     }
     
     func goToNextPage() {
-        if isNextEnabled && currentIndex < totalSteps - 1 {
+        if isNextButtonEnabled() && currentIndex < totalSteps - 1 {
             resetValuesForNextPage()
             currentIndex += 1
-            DispatchQueue.main.async { self.updateNextButtonState() }
         }
     }
     
@@ -96,58 +59,52 @@ class AddMeetingViewModel: ObservableObject {
         selectedCycle = nil
     }
     
-    func updateNextButtonState() {
-        switch self.currentIndex {
+    func isNextButtonEnabled() -> Bool {
+        switch currentIndex {
         case 0:
-            self.isNextEnabled = self.selectedCycle != nil
+            return selectedCycle != nil
         case 1:
-            self.isNextEnabled = self.selectedCycle == .once
-            ? self.selectedWeekDate != nil
-            : self.selectedWeekDay != nil
+            return selectedCycle == .once
+            ? selectedWeekDate != nil
+            : selectedWeekDay != nil
         case 2:
-            self.isNextEnabled = self.selectedTimeRange.start > 0 && self.selectedTimeRange.end > self.selectedTimeRange.start
+            return selectedTimeRange.start > 0 && selectedTimeRange.end > selectedTimeRange.start
         case 3:
-            self.isNextEnabled = self.selectedCategory != nil
+            return selectedCategory != nil
         case 4:
-            self.isNextEnabled = self.selectedCoverIndex != nil
+            return selectedCoverIndex != nil
         case 5:
-            self.isNextEnabled = self.location.count >= 2
+            return location.count >= 2
         case 6:
-            self.isNextEnabled = self.title.count >= 2
+            return title.count >= 2
         case 7:
-            self.isNextEnabled = true
+            return true
         default:
-            self.isNextEnabled = false
+            return false
         }
     }
     
     func resetValuesForNextPage() {
         switch self.currentIndex {
         case 0:
-            self.selectedWeekDate = nil
-            self.selectedWeekDay = nil
-            
+            selectedWeekDate = nil
+            selectedWeekDay = nil
         case 1:
-            self.selectedTimeRange = (0, 0)
-            self.selectedCells = Set([])
-            
+            selectedTimeRange = (0, 0)
+            selectedCells = Set([])
         case 2:
-            self.selectedCategory = nil
-            
+            selectedCategory = nil
         case 3:
-            self.selectedCoverIndex = nil
-            
+            selectedCoverIndex = nil
         case 4:
-            self.location = ""
-            
+            location = ""
+            maxPeopleCount = 2
         case 5:
-            self.title = ""
-            self.introduction = ""
-            
+            title = ""
+            introduction = ""
         default:
             break
         }
-        DispatchQueue.main.async { self.updateNextButtonState() }
     }
     
     func updateSelectedWeekDay() {
@@ -296,7 +253,4 @@ class AddMeetingViewModel: ObservableObject {
             introduction: introduction
         )
     }
-    
 }
-
-

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Login/LoginViewModel.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Login/LoginViewModel.swift
@@ -39,7 +39,7 @@ class LoginViewModel: NSObject, ObservableObject {
             self.isSignedIn = true
             
             DispatchQueue.main.async {
-                if let userId = data.userId {
+                if data.userId != nil {
                     // 기존 유저 -> 토큰 저장 후 main으로
                     TokenManager.shared.updateToken(data.accessToken, data.refreshToken)
                     self.loginFlow = .existingUser

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingDetail/View/MeetingDetailView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingDetail/View/MeetingDetailView.swift
@@ -17,10 +17,13 @@ struct MeetingDetailView: View {
     var body: some View {
         ZStack {
             VStack(spacing: 0) {
-                MeetingInfoBase(
-                    state: .detail,
-                    meeting: viewModel.meeting)
-                .padding(16)
+                if let meetingData = viewModel.meeting {
+                    MeetingInfoBase(
+                        state: .detail,
+                        meeting: meetingData
+                    )
+                    .padding(16)
+                }
                 
                 divider()
                 
@@ -109,12 +112,12 @@ extension MeetingDetailView {
                     }
                     viewModel.alertType = nil
                 })
-        case .error(let isGetMethod):
+        case .error:
             GongbaekAlert(
                 alertImage: "img_fail" ,
-                titleText: isGetMethod ? "앗! 데이터를 불러오지 못했어요." : "일시적인 오류가 발생했습니다.",
-                subtitleText: isGetMethod ? "잠시 후 다시 시도해주세요." : "잠시 후 다시 시도해주세요.",
-                orangeButtonText: isGetMethod ? "확인" : "닫기",
+                titleText: "일시적인 오류가 발생했습니다.",
+                subtitleText: "잠시 후 다시 시도해주세요.",
+                orangeButtonText: "닫기",
                 onTapOrangeButton: {
                     viewModel.alertType = nil
                 }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingDetail/View/MeetingDetailView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingDetail/View/MeetingDetailView.swift
@@ -17,10 +17,10 @@ struct MeetingDetailView: View {
     var body: some View {
         ZStack {
             VStack(spacing: 0) {
-                if let meetingData = viewModel.meeting {
+                if let meetingData = viewModel.meetingDetailData {
                     MeetingInfoBase(
                         state: .detail,
-                        meeting: meetingData
+                        meeting: viewModel.meeting(for: meetingData)
                     )
                     .padding(16)
                 }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingDetail/View/MeetingDetailView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingDetail/View/MeetingDetailView.swift
@@ -124,7 +124,10 @@ extension MeetingDetailView {
                 viewModel.alertType = nil
                 viewModel.fetchAllData(groupId: groupId, groupType: groupType)
             })
-            .customNavigationBar(showBackButton: true)
+            .customNavigationBar(
+                viewName: "채우기",
+                showBackButton: true
+            )
         }
     }
 }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingDetail/ViewModel/MeetingDetailViewModel.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingDetail/ViewModel/MeetingDetailViewModel.swift
@@ -300,4 +300,25 @@ extension MeetingDetailViewModel {
             }
         }
     }
+    
+    func deleteComment(groupId: Int, groupType: String, commentId: Int) {
+        let requestData = DeleteCommentRequestDTO(commentId: commentId)
+        
+        Providers.commentProvider.request(
+            target: .deleteComment(data: requestData),
+            instance: BaseResponse<EmptyResponseDTO>.self) { response in
+            DispatchQueue.main.async {
+                if response.success {
+                    print("✅ 댓글 삭제 성공!")
+                } else {
+                    self.alertType = .error(isGetMethod: false)
+                    print("❌ 댓글 삭제 실패: \(response.message ?? "알 수 없는 오류")")
+                }
+                
+                self.getComments(groupId: groupId, groupType: groupType) { _ in
+                    print("getComments finished, memberData: \(String(describing: self.commentData))")
+                }
+            }
+        }
+    }
 }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingDetail/ViewModel/MeetingDetailViewModel.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingDetail/ViewModel/MeetingDetailViewModel.swift
@@ -108,26 +108,36 @@ class MeetingDetailViewModel: ObservableObject {
 }
 
 extension MeetingDetailViewModel {
+    
     func fetchAllData(groupId: Int, groupType: String) {
         let dispatchGroup = DispatchGroup()
         
+        var meetingDetailData: GetMeetingDetailsResponseDTO? = nil
+        var ownerInfoData: GetOwnerInfoResponseDTO? = nil
+        var commentData: GetCommentsResponseDTO? = nil
+        
         dispatchGroup.enter()
-        getDetails(groupId: groupId, groupType: groupType) { _ in
+        getDetails(groupId: groupId, groupType: groupType) { data in
+            meetingDetailData = data
             dispatchGroup.leave()
         }
         
         dispatchGroup.enter()
-        getOwnerInfo(groupId: groupId, groupType: groupType) { _ in
+        getOwnerInfo(groupId: groupId, groupType: groupType) { data in
+            ownerInfoData = data
             dispatchGroup.leave()
         }
         
         dispatchGroup.enter()
-        getComments(groupId: groupId, groupType: groupType) { _ in
+        getComments(groupId: groupId, groupType: groupType) { data in
+            commentData = data
             dispatchGroup.leave()
         }
         
         dispatchGroup.notify(queue: .main) {
-            
+            self.meetingDetailData = meetingDetailData
+            self.ownerInfoData = ownerInfoData
+            self.commentData = commentData
         }
     }
     
@@ -144,10 +154,12 @@ extension MeetingDetailViewModel {
             ),
             instance: BaseResponse<GetMeetingDetailsResponseDTO>.self
         ) { response in
-            if !response.success {
+            if response.success {
+                guard let data = response.data else { return }
+                completion(data)
+            } else {
                 self.alertType = .fullErrorView
             }
-            self.meetingDetailData = response.data
         }
     }
     
@@ -160,10 +172,12 @@ extension MeetingDetailViewModel {
             target: .getOwnerInfo(groupId: groupId, groupType: groupType),
             instance: BaseResponse<GetOwnerInfoResponseDTO>.self
         ) { response in
-            if !response.success {
+            if response.success {
+                guard let data = response.data else { return }
+                completion(data)
+            } else {
                 self.alertType = .fullErrorView
             }
-            self.ownerInfoData = response.data
         }
     }
     
@@ -180,10 +194,12 @@ extension MeetingDetailViewModel {
             ),
             instance: BaseResponse<GetCommentsResponseDTO>.self
         ) { response in
-            if !response.success {
+            if response.success {
+                guard let data = response.data else { return }
+                completion(data)
+            } else {
                 self.alertType = .fullErrorView
             }
-            self.commentData = response.data
         }
     }
     
@@ -192,30 +208,27 @@ extension MeetingDetailViewModel {
             groupId: groupId,
             groupType: groupType
         )
+        
         Providers.meetingDetailProvider.request(
-            target: .postApplyMeeting(
-                data: requestData
-            ),
+            target: .postApplyMeeting(data: requestData),
             instance: BaseResponse<EmptyResponseDTO>.self
         ) { response in
-            DispatchQueue.main.async {
-                if response.success {
-                    self.alertType = .apply
-                    print("✅ 신청 성공!")
-                } else {
-                    switch response.code {
-                    case 4097:
-                        self.alertType = .recruited
-                        print("⚠️ 신청 불가능한 상태 - 인원마감 (code: 4097)")
-                    default:
-                        self.alertType = .error
-                        print("❌ 신청 실패: \(response.message ?? "알 수 없는 오류")")
-                    }
+            if response.success {
+                self.alertType = .apply
+                print("✅ 신청 성공!")
+            } else {
+                switch response.code {
+                case 4097:
+                    self.alertType = .recruited
+                    print("⚠️ 신청 불가능한 상태 - 인원마감 (code: 4097)")
+                default:
+                    self.alertType = .error
+                    print("❌ 신청 실패: \(response.message ?? "알 수 없는 오류")")
                 }
-                
-                self.getDetails(groupId: groupId, groupType: groupType) { _ in
-                    print("getDetails finished result and data: \(String(describing: self.getDetails))")
-                }
+            }
+            
+            self.getDetails(groupId: groupId, groupType: groupType) { data in
+                self.meetingDetailData = data
             }
         }
     }
@@ -227,22 +240,19 @@ extension MeetingDetailViewModel {
         )
         
         Providers.meetingDetailProvider.request(
-            target: .patchApplyMeeting(
-                data: requestData
-            ),
+            target: .patchApplyMeeting(data: requestData),
             instance: BaseResponse<EmptyResponseDTO>.self
         ) { response in
-            DispatchQueue.main.async {
-                if response.success {
-                    self.alertType = .cancel
-                    print("✅ 취소 성공!")
-                } else {
-                    self.alertType = .error
-                    print("❌ 취소 실패: \(response.message ?? "알 수 없는 오류")")
-                }
-                self.getDetails(groupId: groupId, groupType: groupType) { _ in
-                    print("getDetails finished result and data: \(String(describing: self.getDetails))")
-                }
+            if response.success {
+                self.alertType = .cancel
+                print("✅ 취소 성공!")
+            } else {
+                self.alertType = .error
+                print("❌ 취소 실패: \(response.message ?? "알 수 없는 오류")")
+            }
+            
+            self.getDetails(groupId: groupId, groupType: groupType) { data in
+                self.meetingDetailData = data
             }
         }
     }
@@ -255,17 +265,18 @@ extension MeetingDetailViewModel {
             body: commentContent
         )
         
-        Providers.commentProvider.request(target: .postComment(data: requestData), instance: BaseResponse<EmptyResponseDTO>.self) { response in
-            DispatchQueue.main.async {
-                if response.success {
-                    print("✅ 댓글 등록 성공!")
-                } else {
-                    self.alertType = .error
-                    print("❌ 댓글 등록 실패: \(response.message ?? "알 수 없는 오류")")
+        Providers.commentProvider.request(
+            target: .postComment(data: requestData),
+            instance: BaseResponse<EmptyResponseDTO>.self
+        ) { response in
+            if response.success {
+                print("✅ 댓글 등록 성공!")
+                self.getComments(groupId: groupId, groupType: groupType) { data in
+                    self.commentData = data
                 }
-                self.getComments(groupId: groupId, groupType: groupType) { _ in
-                    print("getComments finished, memberData: \(String(describing: self.commentData))")
-                }
+            } else {
+                self.alertType = .error
+                print("❌ 댓글 등록 실패: \(response.message ?? "알 수 없는 오류")")
             }
         }
     }
@@ -284,14 +295,12 @@ extension MeetingDetailViewModel {
             target: .deleteMyMeeting(data: requestData),
             instance: BaseResponse<EmptyResponseDTO>.self
         ) { response in
-            DispatchQueue.main.async {
-                if response.success {
-                    print("✅ 삭제 성공!")
-                    completion()
-                } else {
-                    self.alertType = .error
-                    print("❌ 삭제 실패: \(response.message ?? "알 수 없는 오류")")
-                }
+            if response.success {
+                print("✅ 삭제 성공!")
+                completion()
+            } else {
+                self.alertType = .error
+                print("❌ 삭제 실패: \(response.message ?? "알 수 없는 오류")")
             }
         }
     }
@@ -303,17 +312,14 @@ extension MeetingDetailViewModel {
             target: .deleteComment(data: requestData),
             instance: BaseResponse<EmptyResponseDTO>.self
         ) { response in
-            DispatchQueue.main.async {
-                if response.success {
-                    print("✅ 댓글 삭제 성공!")
-                } else {
-                    self.alertType = .error
-                    print("❌ 댓글 삭제 실패: \(response.message ?? "알 수 없는 오류")")
+            if response.success {
+                print("✅ 댓글 삭제 성공!")
+                self.getComments(groupId: groupId, groupType: groupType) { data in
+                    self.commentData = data
                 }
-                
-                self.getComments(groupId: groupId, groupType: groupType) { _ in
-                    print("getComments finished, memberData: \(String(describing: self.commentData))")
-                }
+            } else {
+                self.alertType = .error
+                print("❌ 댓글 삭제 실패: \(response.message ?? "알 수 없는 오류")")
             }
         }
     }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingDetail/ViewModel/MeetingDetailViewModel.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingDetail/ViewModel/MeetingDetailViewModel.swift
@@ -12,7 +12,7 @@ enum MeetingDetailAlertType {
     case recruited
     case cancel
     case delete
-    case error(isGetMethod: Bool = true)
+    case error
     case fullErrorView
 }
 
@@ -191,7 +191,7 @@ extension MeetingDetailViewModel {
                         self.alertType = .recruited
                         print("⚠️ 신청 불가능한 상태 - 인원마감 (code: 4097)")
                     default:
-                        self.alertType = .error(isGetMethod: false)
+                        self.alertType = .error
                         print("❌ 신청 실패: \(response.message ?? "알 수 없는 오류")")
                     }
                 }
@@ -220,7 +220,7 @@ extension MeetingDetailViewModel {
                     self.alertType = .cancel
                     print("✅ 취소 성공!")
                 } else {
-                    self.alertType = .error(isGetMethod: false)
+                    self.alertType = .error
                     print("❌ 취소 실패: \(response.message ?? "알 수 없는 오류")")
                 }
                 self.getDetails(groupId: groupId, groupType: groupType) { _ in
@@ -263,7 +263,7 @@ extension MeetingDetailViewModel {
                 if response.success {
                     print("✅ 댓글 등록 성공!")
                 } else {
-                    self.alertType = .error(isGetMethod: false)
+                    self.alertType = .error
                     print("❌ 댓글 등록 실패: \(response.message ?? "알 수 없는 오류")")
                 }
                 self.getComments(groupId: groupId, groupType: groupType) { _ in
@@ -284,9 +284,7 @@ extension MeetingDetailViewModel {
         )
         
         Providers.meetingDetailProvider.request(
-            target: .deleteMyMeeting(
-                data: requestData
-            ),
+            target: .deleteMyMeeting(data: requestData),
             instance: BaseResponse<EmptyResponseDTO>.self
         ) { response in
             DispatchQueue.main.async {
@@ -294,7 +292,7 @@ extension MeetingDetailViewModel {
                     print("✅ 삭제 성공!")
                     completion()
                 } else {
-                    self.alertType = .error(isGetMethod: false)
+                    self.alertType = .error
                     print("❌ 삭제 실패: \(response.message ?? "알 수 없는 오류")")
                 }
             }
@@ -306,12 +304,13 @@ extension MeetingDetailViewModel {
         
         Providers.commentProvider.request(
             target: .deleteComment(data: requestData),
-            instance: BaseResponse<EmptyResponseDTO>.self) { response in
+            instance: BaseResponse<EmptyResponseDTO>.self
+        ) { response in
             DispatchQueue.main.async {
                 if response.success {
                     print("✅ 댓글 삭제 성공!")
                 } else {
-                    self.alertType = .error(isGetMethod: false)
+                    self.alertType = .error
                     print("❌ 댓글 삭제 실패: \(response.message ?? "알 수 없는 오류")")
                 }
                 

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingDetail/ViewModel/MeetingDetailViewModel.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingDetail/ViewModel/MeetingDetailViewModel.swift
@@ -164,7 +164,7 @@ extension MeetingDetailViewModel {
             instance: BaseResponse<GetOwnerInfoResponseDTO>.self
         ) { response in
             if !response.success {
-                self.alertType = .fullErrorView // ⭐️ 이렇게 alert 필요할 때마다 설정해주면 됨
+                self.alertType = .fullErrorView
             }
             self.ownerInfoData = response.data
         }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingDetail/ViewModel/MeetingDetailViewModel.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingDetail/ViewModel/MeetingDetailViewModel.swift
@@ -22,31 +22,28 @@ class MeetingDetailViewModel: ObservableObject {
     @Published var commentData: GetCommentsResponseDTO? = nil
     @Published var alertType: MeetingDetailAlertType? = nil
     
-    var isHost: Bool { meetingDetailData?.isHost ?? false }
-    var isApply: Bool { meetingDetailData?.isApply ?? false }
-    var meeting: Meeting {
-        Meeting(
-            groupId: meetingDetailData?.groupId ?? 0,
-            status: meetingDetailData?.status ?? "",
-            category: meetingDetailData?.category ?? "카테고리오류",
-            coverImg: meetingDetailData?.coverImg ?? 10,
-            groupType: meetingDetailData?.groupType ?? "",
-            groupTitle: meetingDetailData?.groupTitle ?? "",
-            weekDay: meetingDetailData?.weekDay ?? "",
-            weekDate: meetingDetailData?.weekDate ?? nil,
-            startTime: meetingDetailData?.startTime ?? 0,
-            endTime: meetingDetailData?.endTime ?? 0,
-            location: meetingDetailData?.location ?? ""
-        )}
+    func meeting(for meetingDetailData: GetMeetingDetailsResponseDTO) -> Meeting {
+        return Meeting(
+            groupId: meetingDetailData.groupId,
+            status: meetingDetailData.status,
+            category: meetingDetailData.category,
+            coverImg: meetingDetailData.coverImg,
+            groupType: meetingDetailData.groupType,
+            groupTitle: meetingDetailData.groupTitle,
+            weekDay: meetingDetailData.weekDay,
+            weekDate: meetingDetailData.weekDate,
+            startTime: meetingDetailData.startTime,
+            endTime: meetingDetailData.endTime,
+            location: meetingDetailData.location
+        )
+    }
     
     // MARK: - Button Logic 처리
     
-    var buttonText: String {
-        guard let state = RecruitingState(meetingDetailData?.status ?? "") else {
-            return "알 수 없는 상태"
-        }
+    func buttonText(for meetingDetailData: GetMeetingDetailsResponseDTO) -> String {
+        guard let state = RecruitingState(meetingDetailData.status) else { return "" }
         
-        if isHost {
+        if meetingDetailData.isHost {
             return state == .CLOSED ? "종료된 모임입니다." : "삭제하기"
         }
         
@@ -54,18 +51,16 @@ class MeetingDetailViewModel: ObservableObject {
         case .CLOSED:
             return "종료된 모임입니다."
         case .RECRUITED:
-            return  isApply ? "취소하기" : "인원 마감"
+            return  meetingDetailData.isApply ? "취소하기" : "인원 마감"
         case .RECRUITING:
-            return isApply ? "취소하기" : "신청하기"
+            return meetingDetailData.isApply ? "취소하기" : "신청하기"
         }
     }
     
-    var isActivated: Bool {
-        guard let state = RecruitingState(meetingDetailData?.status) else {
-            return false
-        }
+    func isActivated(for meetingDetailData: GetMeetingDetailsResponseDTO) -> Bool {
+        guard let state = RecruitingState(meetingDetailData.status) else { return false }
         
-        if isHost {
+        if meetingDetailData.isHost {
             return state != .CLOSED
         }
         
@@ -73,18 +68,16 @@ class MeetingDetailViewModel: ObservableObject {
         case .CLOSED:
             return false
         case .RECRUITED:
-            return isApply
+            return meetingDetailData.isApply
         case .RECRUITING:
             return true
         }
     }
     
-    var buttonAction: (() -> Void)? {
-        guard let state = RecruitingState(meetingDetailData?.status) else {
-            return nil
-        }
+    func buttonAction(for meetingDetailData: GetMeetingDetailsResponseDTO) -> (() -> (Void))? {
+        guard let state = RecruitingState(meetingDetailData.status) else { return nil }
         
-        if isHost {
+        if meetingDetailData.isHost {
             return state == .CLOSED
             ? nil
             : { self.alertType = .delete }
@@ -94,21 +87,21 @@ class MeetingDetailViewModel: ObservableObject {
         case .CLOSED:
             return nil
         case .RECRUITED:
-            return isApply
-            ? {self.patchApplyMeeting(
-                groupId: self.meetingDetailData?.groupId ?? 0,
-                groupType: self.meetingDetailData?.groupType ?? ""
+            return meetingDetailData.isApply
+            ? { self.patchApplyMeeting(
+                groupId: meetingDetailData.groupId,
+                groupType: meetingDetailData.groupType
             )}
             : nil
         case .RECRUITING:
-            return isApply
-            ? {self.patchApplyMeeting(
-                groupId: self.meetingDetailData?.groupId ?? 0,
-                groupType: self.meetingDetailData?.groupType ?? ""
+            return meetingDetailData.isApply
+            ? { self.patchApplyMeeting(
+                groupId: meetingDetailData.groupId,
+                groupType: meetingDetailData.groupType
             )}
-            : {self.postApplyMeeting(
-                groupId: self.meetingDetailData?.groupId ?? 0,
-                groupType: self.meetingDetailData?.groupType ?? ""
+            : { self.postApplyMeeting(
+                groupId: meetingDetailData.groupId,
+                groupType: meetingDetailData.groupType
             )}
         }
     }
@@ -131,6 +124,10 @@ extension MeetingDetailViewModel {
         dispatchGroup.enter()
         getComments(groupId: groupId, groupType: groupType) { _ in
             dispatchGroup.leave()
+        }
+        
+        dispatchGroup.notify(queue: .main) {
+            
         }
     }
     
@@ -167,6 +164,26 @@ extension MeetingDetailViewModel {
                 self.alertType = .fullErrorView
             }
             self.ownerInfoData = response.data
+        }
+    }
+    
+    func getComments(
+        groupId: Int,
+        groupType: String,
+        completion: @escaping (GetCommentsResponseDTO) -> ()
+    ) {
+        Providers.commentProvider.request(
+            target: .getComments(
+                isPublic: true,
+                groupId: groupId,
+                groupType: groupType
+            ),
+            instance: BaseResponse<GetCommentsResponseDTO>.self
+        ) { response in
+            if !response.success {
+                self.alertType = .fullErrorView
+            }
+            self.commentData = response.data
         }
     }
     
@@ -227,26 +244,6 @@ extension MeetingDetailViewModel {
                     print("getDetails finished result and data: \(String(describing: self.getDetails))")
                 }
             }
-        }
-    }
-    
-    func getComments(
-        groupId: Int,
-        groupType: String,
-        completion: @escaping (GetCommentsResponseDTO) -> ()
-    ) {
-        Providers.commentProvider.request(
-            target: .getComments(
-                isPublic: true,
-                groupId: groupId,
-                groupType: groupType
-            ),
-            instance: BaseResponse<GetCommentsResponseDTO>.self
-        ) { response in
-            if !response.success {
-                self.alertType = .error()
-            }
-            self.commentData = response.data
         }
     }
     

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingRoom/View/MeetingRoomView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingRoom/View/MeetingRoomView.swift
@@ -19,32 +19,31 @@ struct MeetingRoomView: View {
             VStack(spacing: 0) {
                 ScrollView(.vertical) {
                     VStack(spacing: 0) {
-                        headerCoverImage()
-                        .overlay(
-                            VStack(alignment: .leading, spacing: 0) {
-                                meetingChips()
-                                    .padding(.top, geometry.safeAreaInsets.top + 48 + 18)
-                                
-                                meetingTitle()
-                                
-                                TimeBox(
-                                    state: .white,
-                                    text: Date.formattedDateAndStartEndTime(
-                                        weekDay: WeekDay(viewModel.weekDay),
-                                        weekDate: viewModel.weekDate,
-                                        startTime: viewModel.startTime,
-                                        endTime: viewModel.endTime
-                                    ),
-                                    font: .pretendard(.caption2_r_12)
-                                )
-                                .padding(.bottom, 2)
-                                
-                                LocationBox(state: .white, text: viewModel.location, font: .pretendard(.caption2_r_12))
-                            }
-                            .padding(.horizontal, 16)
-                            .padding(.bottom, 16)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                        )
+                        headerCoverImage(safeAreaTopInset: geometry.safeAreaInsets.top)
+                            .overlay(
+                                VStack(alignment: .leading, spacing: 0) {
+                                    meetingChips()
+                                    meetingTitle()
+                                    
+                                    TimeBox(
+                                        state: .white,
+                                        text: Date.formattedDateAndStartEndTime(
+                                            weekDay: WeekDay(viewModel.weekDay),
+                                            weekDate: viewModel.weekDate,
+                                            startTime: viewModel.startTime,
+                                            endTime: viewModel.endTime
+                                        ),
+                                        font: .pretendard(.caption2_r_12)
+                                    )
+                                    .padding(.bottom, 2)
+                                    
+                                    LocationBox(state: .white, text: viewModel.location, font: .pretendard(.caption2_r_12))
+                                }
+                                .padding(.top, geometry.safeAreaInsets.top + 48 + 18)
+                                .padding(.horizontal, 16)
+                                .padding(.bottom, 16)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                            )
                         
                         meetingMembers()
                         divider()
@@ -102,26 +101,27 @@ struct MeetingRoomView: View {
 
 private extension MeetingRoomView {
     
-    func headerCoverImage() -> some View {
-        Group {
+    func headerCoverImage(safeAreaTopInset: CGFloat) -> some View {
+        let height = safeAreaTopInset + 48 + 134
+        return Group {
             if let data = viewModel.meetingDetailData,
                let category = CategoryState(data.category) {
                 Image(category.coverImage[data.coverImg])
                     .resizable()
                     .scaledToFill()
-                    .frame(height: 232)
+                    .frame(height: height)
                     .clipped()
                     .overlay(
                         Rectangle()
                             .fill(Color.grayBlack.opacity(0.5))
-                            .frame(height: 232),
+                            .frame(height: height),
                         alignment: .center
                     )
             }
             else {
                 Rectangle()
                     .fill(.gray01)
-                    .frame(height: 232)
+                    .frame(height: height)
             }
         }
     }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingRoom/View/MeetingRoomView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingRoom/View/MeetingRoomView.swift
@@ -15,139 +15,140 @@ struct MeetingRoomView: View {
     let groupType: String
     
     var body: some View {
-        VStack(spacing: 0) {
-            
-            ScrollView(.vertical) {
-                VStack(spacing: 0) {
-                    Group {
-                        if let data = viewModel.meetingDetailData,
-                           let category = CategoryState(data.category) {
-                            Image(category.coverImage[data.coverImg - 1])
-                                .resizable()
-                                .scaledToFill()
-                                .frame(height: 232)
-                                .clipped()
-                                .overlay(
-                                    Rectangle()
-                                        .fill(Color.grayBlack.opacity(0.5))
-                                        .frame(height: 232),
-                                    alignment: .center
-                                )
-                        }
-                        else { Image(.sample)
-                                .resizable()
-                                .scaledToFill()
-                                .frame(height: 232)
-                            .clipped() }
-                    }
-                    .overlay(
-                        VStack(alignment: .leading, spacing: 0) {
-                            HStack(spacing: 5) {
-                                ForEach(viewModel.meetingStates.indices, id: \.self) { index in
-                                    MeetingChip(state: viewModel.meetingStates[index])
-                                }                            }
-                            .padding(.top, 116)
-                            
-                            Text(viewModel.groupTitle)
-                                .pretendardFont(.title1_b_20)
-                                .foregroundColor(.grayWhite)
-                                .lineLimit(nil)
-                                .padding(.bottom, 12)
-                            
-                            TimeBox(
-                                state: .white,
-                                text: Date.formattedDateAndStartEndTime(
-                                    weekDay: WeekDay(viewModel.weekDay),
-                                    weekDate: viewModel.weekDate,
-                                    startTime: viewModel.startTime,
-                                    endTime: viewModel.endTime
-                                ),
-                                font: .pretendard(.caption2_r_12)
-                            )
-                            .padding(.bottom, 2)
-                            LocationBox(state: .white, text: viewModel.location, font: .pretendard(.caption2_r_12))
-                        }
-                            .padding(.horizontal, 16)
-                            .padding(.bottom, 16)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    )
-                    VStack(alignment: .leading, spacing: 0) {
-                        HStack {
-                            Image(.icPeople18)
-                                .resizable()
-                                .frame(width: 18, height: 18)
-                                .foregroundStyle(.gray06)
-                            
-                            Text(viewModel.memberCount)
-                                .pretendardFont(.title2_sb_18)
-                                .foregroundStyle(.gray10)
-                        }
-                        .padding(.top, 16)
-                        .padding(.bottom, 12)
-                        .padding(.horizontal, 16)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        //                        .background(.grayWhite)
-                    }
-                    
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: 6) {
-                            if let memberData = viewModel.memberData {
-                                ForEach(memberData.members.indices, id: \.self) { index in
-                                    MemberProfileBox(memberData: memberData.members[index])
-                                }
+        GeometryReader { geometry in
+            VStack(spacing: 0) {
+                ScrollView(.vertical) {
+                    VStack(spacing: 0) {
+                        Group {
+                            if let data = viewModel.meetingDetailData,
+                               let category = CategoryState(data.category) {
+                                Image(category.coverImage[data.coverImg])
+                                    .resizable()
+                                    .scaledToFill()
+                                    .frame(height: 232)
+                                    .clipped()
+                                    .overlay(
+                                        Rectangle()
+                                            .fill(Color.grayBlack.opacity(0.5))
+                                            .frame(height: 232),
+                                        alignment: .center
+                                    )
+                            }
+                            else { Image(.sample)
+                                    .resizable()
+                                    .scaledToFill()
+                                    .frame(height: 232)
+                                    .clipped()
                             }
                         }
-                        .padding(.horizontal, 9)
-                        .padding(.bottom, 16)
+                        .overlay(
+                            VStack(alignment: .leading, spacing: 0) {
+                                HStack(spacing: 5) {
+                                    ForEach(viewModel.meetingStates.indices, id: \.self) { index in
+                                        MeetingChip(state: viewModel.meetingStates[index])
+                                    }
+                                }
+                                .padding(.top, geometry.safeAreaInsets.top + 48 + 18)
+                                
+                                Text(viewModel.groupTitle)
+                                    .pretendardFont(.title1_b_20)
+                                    .foregroundColor(.grayWhite)
+                                    .lineLimit(nil)
+                                    .padding(.top, 6)
+                                    .padding(.bottom, 12)
+                                
+                                TimeBox(
+                                    state: .white,
+                                    text: Date.formattedDateAndStartEndTime(
+                                        weekDay: WeekDay(viewModel.weekDay),
+                                        weekDate: viewModel.weekDate,
+                                        startTime: viewModel.startTime,
+                                        endTime: viewModel.endTime
+                                    ),
+                                    font: .pretendard(.caption2_r_12)
+                                )
+                                .padding(.bottom, 2)
+                                
+                                LocationBox(state: .white, text: viewModel.location, font: .pretendard(.caption2_r_12))
+                            }
+                                .padding(.horizontal, 16)
+                                .padding(.bottom, 16)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        )
+                        VStack(alignment: .leading, spacing: 0) {
+                            HStack {
+                                Image(.icPeople18)
+                                    .resizable()
+                                    .frame(width: 18, height: 18)
+                                    .foregroundStyle(.gray06)
+                                
+                                Text(viewModel.memberCount)
+                                    .pretendardFont(.title2_sb_18)
+                                    .foregroundStyle(.gray10)
+                            }
+                            .padding(.top, 16)
+                            .padding(.bottom, 12)
+                            .padding(.horizontal, 16)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack(spacing: 6) {
+                                if let memberData = viewModel.memberData {
+                                    ForEach(memberData.members.indices, id: \.self) { index in
+                                        MemberProfileBox(memberData: memberData.members[index])
+                                    }
+                                }
+                            }
+                            .padding(.horizontal, 9)
+                            .padding(.bottom, 16)
+                        }
+                        
+                        divider()
+                        
+                        viewModel.isCommentDisabled ? CommentDisabledBox() : nil
                     }
-                    //                    .background(.grayWhite)
                     
-                    divider()
-                    
-                    viewModel.isCommentDisabled ? CommentDisabledBox() : nil
+                    CommentList(
+                        meetingRoomViewModel: viewModel,
+                        commentCount: viewModel.commentData?.commentCount ?? 0,
+                        comments: viewModel.commentData?.comments ?? [],
+                        isScrolled: false
+                    )
+                    .frame(maxHeight: .infinity)
                 }
+                .ignoresSafeArea()
                 
-                
-                CommentList(
-                    meetingRoomViewModel: viewModel,
-                    commentCount: viewModel.commentData?.commentCount ?? 0,
-                    comments: viewModel.commentData?.comments ?? [],
-                    isScrolled: false
-                )
-                .frame(maxHeight: .infinity)
+                viewModel.isCommentDisabled ? nil : CommentTextField(meetingRoomViewModel: viewModel)
+                    .padding(0)
             }
-            .ignoresSafeArea()
-            
-            viewModel.isCommentDisabled ? nil : CommentTextField(meetingRoomViewModel: viewModel)
-                .padding(0)
-        }
-        .onTapGesture {
-            hideKeyboard()
-        }
-        .customNavigationBar(isMeetingRoom: true, showBackButton: true)
-        .onAppear {
-            viewModel.fetchAllData(groupId: groupId, groupType: groupType)
-        }
-        
-        if viewModel.showFullErrorView {
-            FullErrorView(onTapRetryButton: {
-                viewModel.showFullErrorView = false
-                
+            .customNavigationBar(isMeetingRoom: true, showBackButton: true)
+            .onTapGesture {
+                hideKeyboard()
+            }
+            .onAppear {
                 viewModel.fetchAllData(groupId: groupId, groupType: groupType)
-            })
-            .customNavigationBar(showBackButton: true)
-        }
-        
-        if viewModel.showErrorAlert {
-            GongbaekAlert(
-                alertImage: "img_fail" ,
-                titleText: "앗! 데이터를 불러오지 못했어요.",
-                subtitleText: "다시 시도해주세요.",
-                orangeButtonText: "확인",
-                onTapOrangeButton: {
-                    viewModel.showErrorAlert = false
-                }
-            )
+            }
+            
+            if viewModel.showFullErrorView {
+                FullErrorView(onTapRetryButton: {
+                    viewModel.showFullErrorView = false
+                    viewModel.fetchAllData(groupId: groupId, groupType: groupType)
+                })
+                .customNavigationBar(showBackButton: true)
+            }
+            
+            if viewModel.showErrorAlert {
+                GongbaekAlert(
+                    alertImage: "img_fail" ,
+                    titleText: "앗! 데이터를 불러오지 못했어요.",
+                    subtitleText: "다시 시도해주세요.",
+                    orangeButtonText: "확인",
+                    onTapOrangeButton: {
+                        viewModel.showErrorAlert = false
+                    }
+                )
+            }
         }
     }
     

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingRoom/View/MeetingRoomView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingRoom/View/MeetingRoomView.swift
@@ -17,50 +17,64 @@ struct MeetingRoomView: View {
     var body: some View {
         GeometryReader { geometry in
             VStack(spacing: 0) {
-                ScrollView(.vertical) {
-                    VStack(spacing: 0) {
-                        headerCoverImage(safeAreaTopInset: geometry.safeAreaInsets.top)
+                if let meetingData = viewModel.meetingDetailData,
+                   let commentData = viewModel.commentData {
+                    ScrollView(.vertical) {
+                        VStack(spacing: 0) {
+                            headerCoverImage(
+                                category: meetingData.category,
+                                coverImageIndex: meetingData.coverImg,
+                                safeAreaTopInset: geometry.safeAreaInsets.top
+                            )
                             .overlay(
                                 VStack(alignment: .leading, spacing: 0) {
                                     meetingChips()
-                                    meetingTitle()
+                                    meetingTitle(meetingData.groupTitle)
                                     
                                     TimeBox(
                                         state: .white,
                                         text: Date.formattedDateAndStartEndTime(
-                                            weekDay: WeekDay(viewModel.weekDay),
-                                            weekDate: viewModel.weekDate,
-                                            startTime: viewModel.startTime,
-                                            endTime: viewModel.endTime
+                                            weekDay: WeekDay(meetingData.weekDay),
+                                            weekDate: meetingData.weekDate,
+                                            startTime: meetingData.startTime,
+                                            endTime: meetingData.endTime
                                         ),
                                         font: .pretendard(.caption2_r_12)
                                     )
                                     .padding(.bottom, 2)
                                     
-                                    LocationBox(state: .white, text: viewModel.location, font: .pretendard(.caption2_r_12))
+                                    LocationBox(
+                                        state: .white,
+                                        text: meetingData.location,
+                                        font: .pretendard(.caption2_r_12)
+                                    )
                                 }
                                 .padding(.top, geometry.safeAreaInsets.top + 48 + 18)
                                 .padding(.horizontal, 16)
                                 .padding(.bottom, 16)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                             )
+                            
+                            meetingMembers(
+                                current: meetingData.currentPeopleCount,
+                                max: meetingData.maxPeopleCount
+                            )
+                            divider()
+                            viewModel.isCommentDisabled ? CommentDisabledBox() : nil
+                        }
                         
-                        meetingMembers()
-                        divider()
-                        viewModel.isCommentDisabled ? CommentDisabledBox() : nil
+                        CommentList(
+                            meetingRoomViewModel: viewModel,
+                            commentCount: commentData.commentCount,
+                            comments: commentData.comments,
+                            isScrolled: false
+                        )
+                        .frame(maxHeight: .infinity)
                     }
+                    .ignoresSafeArea()
                     
-                    CommentList(
-                        meetingRoomViewModel: viewModel,
-                        commentCount: viewModel.commentData?.commentCount ?? 0,
-                        comments: viewModel.commentData?.comments ?? [],
-                        isScrolled: false
-                    )
-                    .frame(maxHeight: .infinity)
+                    viewModel.isCommentDisabled ? nil : CommentTextField(meetingRoomViewModel: viewModel)
                 }
-                .ignoresSafeArea()
-                
-                viewModel.isCommentDisabled ? nil : CommentTextField(meetingRoomViewModel: viewModel)
             }
             .customNavigationBar(
                 isMeetingRoom: viewModel.showFullErrorView ? false : true,
@@ -101,12 +115,15 @@ struct MeetingRoomView: View {
 
 private extension MeetingRoomView {
     
-    func headerCoverImage(safeAreaTopInset: CGFloat) -> some View {
+    func headerCoverImage(
+        category: String,
+        coverImageIndex: Int,
+        safeAreaTopInset: CGFloat
+    ) -> some View {
         let height = safeAreaTopInset + 48 + 134
         return Group {
-            if let data = viewModel.meetingDetailData,
-               let category = CategoryState(data.category) {
-                Image(category.coverImage[data.coverImg])
+            if let category = CategoryState(category) {
+                Image(category.coverImage[coverImageIndex])
                     .resizable()
                     .scaledToFill()
                     .frame(height: height)
@@ -134,8 +151,8 @@ private extension MeetingRoomView {
         }
     }
     
-    func meetingTitle() -> some View {
-        Text(viewModel.groupTitle)
+    func meetingTitle(_ title: String) -> some View {
+        Text(title)
             .pretendardFont(.title1_b_20)
             .foregroundColor(.grayWhite)
             .lineLimit(nil)
@@ -143,9 +160,9 @@ private extension MeetingRoomView {
             .padding(.bottom, 12)
     }
     
-    func meetingMembers() -> some View {
+    func meetingMembers(current: Int, max: Int) -> some View {
         VStack(spacing: 0) {
-            memberTitle()
+            memberTitle(current, max)
             
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 6) {
@@ -161,7 +178,7 @@ private extension MeetingRoomView {
         }
     }
     
-    func memberTitle() -> some View {
+    func memberTitle(_ current: Int, _ max: Int) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack {
                 Image(.icPeople18)
@@ -169,7 +186,7 @@ private extension MeetingRoomView {
                     .frame(width: 18, height: 18)
                     .foregroundStyle(.gray06)
                 
-                Text(viewModel.memberCount)
+                Text("멤버 (\(current)/\(max)명)")
                     .pretendardFont(.title2_sb_18)
                     .foregroundStyle(.gray10)
             }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingRoom/View/MeetingRoomView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingRoom/View/MeetingRoomView.swift
@@ -63,7 +63,10 @@ struct MeetingRoomView: View {
                 
                 viewModel.isCommentDisabled ? nil : CommentTextField(meetingRoomViewModel: viewModel)
             }
-            .customNavigationBar(isMeetingRoom: true, showBackButton: true)
+            .customNavigationBar(
+                isMeetingRoom: viewModel.showFullErrorView ? false : true,
+                showBackButton: true
+            )
             .onTapGesture {
                 hideKeyboard()
             }
@@ -76,7 +79,10 @@ struct MeetingRoomView: View {
                     viewModel.showFullErrorView = false
                     viewModel.fetchAllData(groupId: groupId, groupType: groupType)
                 })
-                .customNavigationBar(showBackButton: true)
+                .customNavigationBar(
+                    viewName: viewModel.showFullErrorView ? "스페이스" : nil,
+                    showBackButton: true
+                )
             }
             
             if viewModel.showErrorAlert {

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingRoom/View/MeetingRoomView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingRoom/View/MeetingRoomView.swift
@@ -119,11 +119,9 @@ private extension MeetingRoomView {
                     )
             }
             else {
-                Image(.sample)
-                    .resizable()
-                    .scaledToFill()
+                Rectangle()
+                    .fill(.gray01)
                     .frame(height: 232)
-                    .clipped()
             }
         }
     }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingRoom/View/MeetingRoomView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingRoom/View/MeetingRoomView.swift
@@ -19,43 +19,13 @@ struct MeetingRoomView: View {
             VStack(spacing: 0) {
                 ScrollView(.vertical) {
                     VStack(spacing: 0) {
-                        Group {
-                            if let data = viewModel.meetingDetailData,
-                               let category = CategoryState(data.category) {
-                                Image(category.coverImage[data.coverImg])
-                                    .resizable()
-                                    .scaledToFill()
-                                    .frame(height: 232)
-                                    .clipped()
-                                    .overlay(
-                                        Rectangle()
-                                            .fill(Color.grayBlack.opacity(0.5))
-                                            .frame(height: 232),
-                                        alignment: .center
-                                    )
-                            }
-                            else { Image(.sample)
-                                    .resizable()
-                                    .scaledToFill()
-                                    .frame(height: 232)
-                                    .clipped()
-                            }
-                        }
+                        headerCoverImage()
                         .overlay(
                             VStack(alignment: .leading, spacing: 0) {
-                                HStack(spacing: 5) {
-                                    ForEach(viewModel.meetingStates.indices, id: \.self) { index in
-                                        MeetingChip(state: viewModel.meetingStates[index])
-                                    }
-                                }
-                                .padding(.top, geometry.safeAreaInsets.top + 48 + 18)
+                                meetingChips()
+                                    .padding(.top, geometry.safeAreaInsets.top + 48 + 18)
                                 
-                                Text(viewModel.groupTitle)
-                                    .pretendardFont(.title1_b_20)
-                                    .foregroundColor(.grayWhite)
-                                    .lineLimit(nil)
-                                    .padding(.top, 6)
-                                    .padding(.bottom, 12)
+                                meetingTitle()
                                 
                                 TimeBox(
                                     state: .white,
@@ -71,41 +41,13 @@ struct MeetingRoomView: View {
                                 
                                 LocationBox(state: .white, text: viewModel.location, font: .pretendard(.caption2_r_12))
                             }
-                                .padding(.horizontal, 16)
-                                .padding(.bottom, 16)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        )
-                        VStack(alignment: .leading, spacing: 0) {
-                            HStack {
-                                Image(.icPeople18)
-                                    .resizable()
-                                    .frame(width: 18, height: 18)
-                                    .foregroundStyle(.gray06)
-                                
-                                Text(viewModel.memberCount)
-                                    .pretendardFont(.title2_sb_18)
-                                    .foregroundStyle(.gray10)
-                            }
-                            .padding(.top, 16)
-                            .padding(.bottom, 12)
                             .padding(.horizontal, 16)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-                        
-                        ScrollView(.horizontal, showsIndicators: false) {
-                            HStack(spacing: 6) {
-                                if let memberData = viewModel.memberData {
-                                    ForEach(memberData.members.indices, id: \.self) { index in
-                                        MemberProfileBox(memberData: memberData.members[index])
-                                    }
-                                }
-                            }
-                            .padding(.horizontal, 9)
                             .padding(.bottom, 16)
-                        }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        )
                         
+                        meetingMembers()
                         divider()
-                        
                         viewModel.isCommentDisabled ? CommentDisabledBox() : nil
                     }
                     
@@ -120,7 +62,6 @@ struct MeetingRoomView: View {
                 .ignoresSafeArea()
                 
                 viewModel.isCommentDisabled ? nil : CommentTextField(meetingRoomViewModel: viewModel)
-                    .padding(0)
             }
             .customNavigationBar(isMeetingRoom: true, showBackButton: true)
             .onTapGesture {
@@ -149,6 +90,89 @@ struct MeetingRoomView: View {
                     }
                 )
             }
+        }
+    }
+}
+
+private extension MeetingRoomView {
+    
+    func headerCoverImage() -> some View {
+        Group {
+            if let data = viewModel.meetingDetailData,
+               let category = CategoryState(data.category) {
+                Image(category.coverImage[data.coverImg])
+                    .resizable()
+                    .scaledToFill()
+                    .frame(height: 232)
+                    .clipped()
+                    .overlay(
+                        Rectangle()
+                            .fill(Color.grayBlack.opacity(0.5))
+                            .frame(height: 232),
+                        alignment: .center
+                    )
+            }
+            else {
+                Image(.sample)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(height: 232)
+                    .clipped()
+            }
+        }
+    }
+    
+    func meetingChips() -> some View {
+        HStack(spacing: 5) {
+            ForEach(viewModel.meetingStates.indices, id: \.self) { index in
+                MeetingChip(state: viewModel.meetingStates[index])
+            }
+        }
+    }
+    
+    func meetingTitle() -> some View {
+        Text(viewModel.groupTitle)
+            .pretendardFont(.title1_b_20)
+            .foregroundColor(.grayWhite)
+            .lineLimit(nil)
+            .padding(.top, 6)
+            .padding(.bottom, 12)
+    }
+    
+    func meetingMembers() -> some View {
+        VStack(spacing: 0) {
+            memberTitle()
+            
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    if let memberData = viewModel.memberData {
+                        ForEach(memberData.members.indices, id: \.self) { index in
+                            MemberProfileBox(memberData: memberData.members[index])
+                        }
+                    }
+                }
+                .padding(.horizontal, 9)
+                .padding(.bottom, 16)
+            }
+        }
+    }
+    
+    func memberTitle() -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Image(.icPeople18)
+                    .resizable()
+                    .frame(width: 18, height: 18)
+                    .foregroundStyle(.gray06)
+                
+                Text(viewModel.memberCount)
+                    .pretendardFont(.title2_sb_18)
+                    .foregroundStyle(.gray10)
+            }
+            .padding(.top, 16)
+            .padding(.bottom, 12)
+            .padding(.horizontal, 16)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
     

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingRoom/ViewModel/MeetingRoomViewModel.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingRoom/ViewModel/MeetingRoomViewModel.swift
@@ -155,4 +155,27 @@ extension MeetingRoomViewModel {
             }
         }
     }
+    
+    func deleteComment(groupId: Int, groupType: String, commentId: Int) {
+        let requestData = DeleteCommentRequestDTO(commentId: commentId)
+        
+        Providers.commentProvider.request(
+            target: .deleteComment(data: requestData),
+            instance: BaseResponse<EmptyResponseDTO>.self) { response in
+            DispatchQueue.main.async {
+                if response.success {
+                    self.isSuccessGetData = true
+                    print("✅ 댓글 삭제 성공!")
+                } else {
+                    self.showErrorAlert = true
+                    self.isSuccessGetData = false
+                    print("❌ 댓글 삭제 실패: \(response.message ?? "알 수 없는 오류")")
+                }
+                
+                self.getComments(groupId: groupId, groupType: groupType) { _ in
+                    print("getComments finished, memberData: \(String(describing: self.commentData))")
+                }
+            }
+        }
+    }
 }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingRoom/ViewModel/MeetingRoomViewModel.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingRoom/ViewModel/MeetingRoomViewModel.swift
@@ -11,7 +11,6 @@ final class MeetingRoomViewModel: ObservableObject {
     @Published var meetingDetailData: GetMeetingRoomDetailsResponseDTO? = nil
     @Published var memberData: GetMeetingRoomMembersResponseDTO? = nil
     @Published var commentData: GetCommentsResponseDTO? = nil
-    @Published var isSuccessGetData: Bool = true
     @Published var showErrorAlert: Bool = false
     @Published var showFullErrorView: Bool = false
     
@@ -59,24 +58,38 @@ final class MeetingRoomViewModel: ObservableObject {
 }
 
 extension MeetingRoomViewModel {
+    
     func fetchAllData(groupId: Int, groupType: String) {
-            let dispatchGroup = DispatchGroup()
-            
-            dispatchGroup.enter()
-            getDetails(groupId: groupId, groupType: groupType) { _ in
-                dispatchGroup.leave()
-            }
-            
-            dispatchGroup.enter()
-            getMembers(groupId: groupId, groupType: groupType) { _ in
-                dispatchGroup.leave()
-            }
-            
-            dispatchGroup.enter()
-            getComments(groupId: groupId, groupType: groupType) { _ in
-                dispatchGroup.leave()
-            }
+        let dispatchGroup = DispatchGroup()
+        
+        var meetingDetailData: GetMeetingRoomDetailsResponseDTO? = nil
+        var memberData: GetMeetingRoomMembersResponseDTO? = nil
+        var commentData: GetCommentsResponseDTO? = nil
+        
+        dispatchGroup.enter()
+        getDetails(groupId: groupId, groupType: groupType) { data in
+            meetingDetailData = data
+            dispatchGroup.leave()
         }
+        
+        dispatchGroup.enter()
+        getMembers(groupId: groupId, groupType: groupType) { data in
+            memberData = data
+            dispatchGroup.leave()
+        }
+        
+        dispatchGroup.enter()
+        getComments(groupId: groupId, groupType: groupType) { data in
+            commentData = data
+            dispatchGroup.leave()
+        }
+        
+        dispatchGroup.notify(queue: .main) {
+            self.meetingDetailData = meetingDetailData
+            self.memberData = memberData
+            self.commentData = commentData
+        }
+    }
     
     func getMembers(
         groupId: Int,
@@ -87,12 +100,12 @@ extension MeetingRoomViewModel {
             target: .getMembers(isPublic: false, groupId: groupId, groupType: groupType),
             instance: BaseResponse<GetMeetingRoomMembersResponseDTO>.self
         ) { response in
-            if !response.success {
+            if response.success {
+                guard let data = response.data else { return }
+                completion(data)
+            } else {
                 self.showFullErrorView = true
-                self.showErrorAlert = false
             }
-            print(response)
-            self.memberData = response.data
         }
     }
     
@@ -105,12 +118,12 @@ extension MeetingRoomViewModel {
             target: .getMeetingDetails(groupId: groupId, groupType: groupType),
             instance: BaseResponse<GetMeetingRoomDetailsResponseDTO>.self
         ) { response in
-            if !response.success {
+            if response.success {
+                guard let data = response.data else { return }
+                completion(data)
+            } else {
                 self.showFullErrorView = true
-                self.showErrorAlert = false
             }
-            print(response)
-            self.meetingDetailData = response.data
         }
     }
     
@@ -123,10 +136,12 @@ extension MeetingRoomViewModel {
             target: .getComments(isPublic: false, groupId: groupId, groupType: groupType),
             instance: BaseResponse<GetCommentsResponseDTO>.self
         ) { response in
-            if !response.success {
-                self.showErrorAlert = true
+            if response.success {
+                guard let data = response.data else { return }
+                completion(data)
+            } else {
+                self.showFullErrorView = true
             }
-            self.commentData = response.data
         }
     }
     
@@ -138,20 +153,18 @@ extension MeetingRoomViewModel {
             body: commentContent
         )
         
-        Providers.commentProvider.request(target: .postComment(data: requestData), instance: BaseResponse<EmptyResponseDTO>.self) { response in
-            print(requestData)
-            DispatchQueue.main.async {
-                if response.success {
-                    self.isSuccessGetData = true
-                    print("✅ 댓글 등록 성공!")
-                } else {
-                    self.showErrorAlert = true
-                    self.isSuccessGetData = false
-                    print("❌ 댓글 등록 실패: \(response.message ?? "알 수 없는 오류")")
+        Providers.commentProvider.request(
+            target: .postComment(data: requestData),
+            instance: BaseResponse<EmptyResponseDTO>.self
+        ) { response in
+            if response.success {
+                print("✅ 댓글 등록 성공!")
+                self.getComments(groupId: groupId, groupType: groupType) { data in
+                    self.commentData = data
                 }
-                self.getComments(groupId: groupId, groupType: groupType) { _ in
-                    print("getComments finished, memberData: \(String(describing: self.commentData))")
-                }
+            } else {
+                self.showErrorAlert = true
+                print("❌ 댓글 등록 실패: \(response.message ?? "알 수 없는 오류")")
             }
         }
     }
@@ -161,20 +174,16 @@ extension MeetingRoomViewModel {
         
         Providers.commentProvider.request(
             target: .deleteComment(data: requestData),
-            instance: BaseResponse<EmptyResponseDTO>.self) { response in
-            DispatchQueue.main.async {
-                if response.success {
-                    self.isSuccessGetData = true
-                    print("✅ 댓글 삭제 성공!")
-                } else {
-                    self.showErrorAlert = true
-                    self.isSuccessGetData = false
-                    print("❌ 댓글 삭제 실패: \(response.message ?? "알 수 없는 오류")")
+            instance: BaseResponse<EmptyResponseDTO>.self
+        ) { response in
+            if response.success {
+                print("✅ 댓글 삭제 성공!")
+                self.getComments(groupId: groupId, groupType: groupType) { data in
+                    self.commentData = data
                 }
-                
-                self.getComments(groupId: groupId, groupType: groupType) { _ in
-                    print("getComments finished, memberData: \(String(describing: self.commentData))")
-                }
+            } else {
+                self.showErrorAlert = true
+                print("❌ 댓글 삭제 실패: \(response.message ?? "알 수 없는 오류")")
             }
         }
     }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingRoom/ViewModel/MeetingRoomViewModel.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingRoom/ViewModel/MeetingRoomViewModel.swift
@@ -22,36 +22,6 @@ final class MeetingRoomViewModel: ObservableObject {
         ].compactMap { $0 }
     }
     
-    var groupTitle: String {
-        meetingDetailData?.groupTitle ?? ""
-    }
-    
-    var weekDay: String {
-        meetingDetailData?.weekDay ?? ""
-    }
-    
-    var weekDate: String? {
-        meetingDetailData?.weekDate ?? nil
-    }
-    
-    var startTime: Double {
-        meetingDetailData?.startTime ?? 0
-    }
-    
-    var endTime: Double {
-        meetingDetailData?.endTime ?? 0
-    }
-    
-    var location: String {
-        meetingDetailData?.location ?? ""
-    }
-    
-    var memberCount: String {
-        let current = meetingDetailData?.currentPeopleCount ?? 0
-        let max = meetingDetailData?.maxPeopleCount ?? 0
-        return "멤버 (\(current)/\(max)명)"
-    }
-    
     var isCommentDisabled: Bool {
         RecruitingState(commentData?.groupStatus) == .CLOSED
     }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MyPage/View/MyPageView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MyPage/View/MyPageView.swift
@@ -13,22 +13,26 @@ struct MyPageView: View {
     
     var body: some View {
         ZStack {
-            VStack(spacing: 0) {
-                MyProfile(profile: viewModel.myProfile)
-                Rectangle()
-                    .fill(.gray01)
-                    .frame(height: 8)
-                MyPageSegmentControlBar(viewModel: viewModel)
-            }
-            .customNavigationBar(title: "마이페이지", rightButtonType: .setting) {
-                navigationManager.push(view: MyPageDestination.myPageSetting)
+            if let myProfile = viewModel.myProfile {
+                VStack(spacing: 0) {
+                    MyProfile(profile: myProfile)
+                    Rectangle()
+                        .fill(.gray01)
+                        .frame(height: 8)
+                    MyPageSegmentControlBar(viewModel: viewModel)
+                }
+                .customNavigationBar(title: "마이페이지", rightButtonType: .setting) {
+                    navigationManager.push(view: MyPageDestination.myPageSetting)
+                }
             }
             
             if viewModel.showAlert {
                 FullErrorView(onTapRetryButton: {
                     viewModel.showAlert = false
+                    viewModel.getMyProfile()
                     viewModel.getMeetings()
                 })
+                .customNavigationBar(title: "마이페이지")
             }
         }
         .onAppear {

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MyPage/View/MyPageView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MyPage/View/MyPageView.swift
@@ -33,6 +33,7 @@ struct MyPageView: View {
         }
         .onAppear {
             viewModel.getMyProfile()
+            viewModel.getMeetings()
         }
     }
 }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MyPage/View/MyProfile.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MyPage/View/MyProfile.swift
@@ -8,11 +8,11 @@
 import SwiftUI
 
 struct MyProfile: View {
-    var profile: GetMyProfileResponseDTO?
+    var profile: GetMyProfileResponseDTO
     
     var body: some View {
         HStack(spacing: 14) {
-            let imageIndex = profile?.profileImg  ?? 0
+            let imageIndex = profile.profileImg
             let profileImage = ProfileDefaultImageMap(rawValue: imageIndex)?.image ?? .imgProfileDefault0
             
             Image(profileImage)
@@ -24,10 +24,10 @@ struct MyProfile: View {
                 .cornerRadius(2)
             
             VStack(alignment: .leading, spacing: 0) {
-                Text(profile?.nickname ?? "이름 없음")
+                Text(profile.nickname)
                     .pretendardFont(.title1_m_20)
                     .foregroundColor(.grayBlack)
-                Text("\(profile?.schoolName ?? "학교 정보 없음") | \(profile?.majorName ?? "학과 정보 없음")")
+                Text("\(profile.schoolName) | \(profile.majorName)")
                     .pretendardFont(.body2_r_14)
                     .foregroundColor(.gray08)
             }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MyPage/ViewModel/MyPageViewModel.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MyPage/ViewModel/MyPageViewModel.swift
@@ -31,8 +31,11 @@ class MyPageViewModel: ObservableObject {
             instance: BaseResponse<GetMyProfileResponseDTO>.self
         ) { response in
             if response.success {
+                self.showAlert = false
                 self.myProfile = response.data
-            } 
+            } else {
+                self.showAlert = true
+            }
         }
     }
     

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/ViewModel/SignupViewModel.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/Signup/ViewModel/SignupViewModel.swift
@@ -74,9 +74,7 @@ final class SignupViewModel: ObservableObject {
             return profileImageIndex != nil
         case .mbtiSelection:
             return e_i != nil && s_n != nil && t_f != nil && j_p != nil
-        case .selfIntroductionWriting:
-            return introduction.count > 0
-        case .classTimeTableInput, .signupCompletion:
+        case .selfIntroductionWriting, .classTimeTableInput, .signupCompletion:
             return true
         }
     }


### PR DESCRIPTION
## 🧩 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 코드가 추가가 된 건 거의 없고! 거의 UI 디테일 수정, UX라이팅 수정, 가독성 개선, 코드 정리(줄바꿈/공백 제거 등)가 대부분입니다.
  - 크게크게 보자면
    - 댓글 삭제 API 연결
    - 모임 모집 화면 텍스트 입력 시 키보드 관련 처리
    - 모임 모집 화면 다음 버튼 활성화 상태 로직 리팩토링
    - 내비게이션바 수정
    - 기본값으로 쓰인 샘플 이미지 삭제 -> 그냥 Rectangle() 넣음
    - ⭐️ ?? 사용한 기본값들 대부분 삭제 (if let 사용해서 서버 데이터 들어와야 뷰 그려지게 함)
    - 뷰모델 API 호출 후, 에러 대응 로직 리팩토링
    - 탈퇴자 댓글 '알 수 없음' 처리

## 🪁 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
- 정말정말 죄송한 점... 제가 ㅁ1친것처럼 민서와 희은이의 코드를 마음대로 리팩토링했답니다~; 😧 혼날게요 ..ㅜ
- 사실 자체 QA하다가 시급해보이는 것들 아가들에게 얘기해줄 시간도 없어서 
- 일단 고쳐야 빠를 것 같아서 몇개 수정하다보니... 이렇게 많아졌답니다;; 저도 깜짝 놀랐지 뭐예요 
- 평소에 맘에 안 들었던 디폴트값 !!! 없애는 작업과.. 그거 없애는 김에 에러 대응도 리팩토링해보고...
- UI 이상한 거 다 하나씩 꼼꼼히 봐보고... 키보드 올라오면 뷰도 깨지길래 이것저것 만져보고... 
- 이렇게 조금씩 하다보니까  5천원 1만5천원씩만 썼던 게,, 갑자기 8억 1249만원 쓴 느낌으로 늘어났어요ㅠㅠ허걱
- 사실 깃 충돌 조금 무서울 지경입니다 

<img width="633" alt="image" src="https://github.com/user-attachments/assets/34b11d54-af36-4013-89a5-00f0fd0154a3" />

- 서버 데이터 if let으로 옵셔널 언래핑해서 디폴트값 삭제하는 방식으로 구현했습니다아

## 📱 스크린샷
<!-- 작업 내용, 스크린 샷(GIF/MP4) 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 구현내용입력 | <img src = "" width ="300">|


### 🔗 Issue 
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Related to #35 
