### PR TITLE
[Fix] - #38 QA사항 1차 수정

### DIFF
--- a/Gongbaek_iOS/Gongbaek_iOS/Global/Component/TextField/CommentTextField.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Global/Component/TextField/CommentTextField.swift
@@ -50,7 +50,7 @@ struct CommentTextField: View {
                     .scaledToFit()
                     .frame(width: 24, height: 24)
             }
-            .disabled(comment.isEmpty)
+            .disabled(comment.isEmpty || isWhiteSpaceText(comment))
             .padding(.bottom, 12)
             .padding(.trailing, 12)
             .foregroundStyle(.mainOrange)
@@ -63,5 +63,9 @@ struct CommentTextField: View {
         .padding(.vertical, 10)
         .padding(.horizontal, 16)
         .background(.grayWhite)
+    }
+    
+    func isWhiteSpaceText(_ text: String) -> Bool {
+        return text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 }

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingDetail/View/MeetingDetailView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingDetail/View/MeetingDetailView.swift
@@ -108,7 +108,8 @@ extension MeetingDetailView {
                 },
                 onTapOrangeButton: {
                     viewModel.deleteMyMeeting(groupId: groupId, groupType: groupType) {
-                        navigationManager.pop()
+                        navigationManager.rootView = .tabBar
+                        navigationManager.selectedTab = .myPage
                     }
                     viewModel.alertType = nil
                 })

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingDetail/ViewModel/MeetingDetailViewModel.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MeetingDetail/ViewModel/MeetingDetailViewModel.swift
@@ -51,9 +51,9 @@ class MeetingDetailViewModel: ObservableObject {
         case .CLOSED:
             return "종료된 모임입니다."
         case .RECRUITED:
-            return  meetingDetailData.isApply ? "취소하기" : "인원 마감"
+            return  meetingDetailData.isApply ? "신청 취소하기" : "인원 마감"
         case .RECRUITING:
-            return meetingDetailData.isApply ? "취소하기" : "신청하기"
+            return meetingDetailData.isApply ? "신청 취소하기" : "신청하기"
         }
     }
     

--- a/Gongbaek_iOS/Gongbaek_iOS/Presentation/MyPageSetting/View/MyPageSettingView.swift
+++ b/Gongbaek_iOS/Gongbaek_iOS/Presentation/MyPageSetting/View/MyPageSettingView.swift
@@ -27,7 +27,12 @@ struct MyPageSettingView: View {
                 }
                 Spacer()
             }
-            
+            .customNavigationBar(viewName: "설정", showBackButton: true)
+            .onChange(of: viewModel.isSignedOut) {
+                if viewModel.isSignedOut {
+                    navigationManager.rootView = .login
+                }
+            }
             if viewModel.showAlert {
                 BasicAlert(
                     titleText: "\(viewModel.selectedAction == .logout ? "로그아웃을" : "회원탈퇴를") 진행하시겠습니까?",
@@ -40,12 +45,6 @@ struct MyPageSettingView: View {
                         viewModel.confirmAction()
                     }
                 )
-            }
-        }
-        .customNavigationBar(viewName: "설정", showBackButton: true)
-        .onChange(of: viewModel.isSignedOut) {
-            if viewModel.isSignedOut {
-                navigationManager.rootView = .login
             }
         }
     }


### PR DESCRIPTION
## 🧩 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 모임상세 - 취소하기 → 신청 취소하기 (라이팅 수정)
- 모임상세 - 삭제하기 클릭 → 마이페이지로 이동으로 수정
- 모임상세 - 공백(띄어쓰기/줄바꿈만 있는거)은 댓글 작성이 안 되도록 막아두기 (스페이스에서도 마찬가지)
- 설정 - 팝업창 뒷 배경 전체 화면을 회색으로 수정 ???

## 🪁 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
- 간단한 수정이라 업뜸!
- 댓글 작성 후 전송 버튼을 눌렀을 때, hideKeyboard가 자동으로 처리된다는 점. 
아무런 입력 사항이 없고 또 띄어쓰기 또는 엔터만 입력을 한 상황이어도 hideKeyboard가 자동으로 처리 됨.
그러나 button의 action이 시행되는 게 아니라는 점...

## 📱 스크린샷
<!-- 작업 내용, 스크린 샷(GIF/MP4) 첨부해주세요. -->
|    구현 내용    |   스크린샷   |    구현 내용    |   스크린샷   |
| :-------------: | :----------: | :-------------: | :----------: |
| 라이팅 변경 [신청 취소하기] | <img src = "https://github.com/user-attachments/assets/f668d7e6-314e-4157-aa1b-6506b98197a4" width ="300">| 삭제하기 클릭 시 플로우 수정 | <img src = "https://github.com/user-attachments/assets/c8aed747-825c-48b2-9ffd-1d99b3edec4b" width ="300">|
| 공백 작성 안되도록 | <img src = "https://github.com/user-attachments/assets/d672300d-704c-4b6c-9b23-6bed374f2a05" width ="300">| 팝업창 뒷배경 수정 | <img src = "https://github.com/user-attachments/assets/44b03967-f214-4617-ae39-c00dc6a3ceef" width ="300">|



### 🔗 Issue 
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #38
